### PR TITLE
fix start-up order, depend worker on redis in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
   worker:
     build:
       context: ./worker
+    depends_on:
+      - "redis"
     networks:
       - back-tier
 


### PR DESCRIPTION
Added "depends_on" for the worker to ensure startup after redis to fix occasional start-up order barfing. Sometimes worker started too early before redis and barfed with:

```
worker_1  |    at System.Net.Dns.<>c.<GetHostEntryAsync>b__16_1(IAsyncResult asyncResult)
worker_1  |    at System.Threading.Tasks.TaskFactory`1.FromAsyncCoreLogic(IAsyncResult iar, Func`2 endFunction, Action`1 endAction, Task`1 promise, Boolean requiresSynchronization)
worker_1  |    --- End of inner exception stack trace ---
worker_1  |    at System.Threading.Tasks.Task`1.GetResultCore(Boolean waitCompletionNotification)
worker_1  |    at Worker.Program.GetIp(String hostname) in /code/src/Worker/Program.cs:line 123
worker_1  |    at Worker.Program.OpenRedisConnection(String hostname) in /code/src/Worker/Program.cs:line 104
worker_1  |    at Worker.Program.Main(String[] args) in /code/src/Worker/Program.cs:line 20
worker_1  | ---> (Inner Exception #0) System.Net.Internals.SocketExceptionFactory+ExtendedSocketException: No such device or address
worker_1  |    at System.Net.Dns.HostResolutionEndHelper(IAsyncResult asyncResult)
worker_1  |    at System.Net.Dns.EndGetHostEntry(IAsyncResult asyncResult)
worker_1  |    at System.Net.Dns.<>c.<GetHostEntryAsync>b__16_1(IAsyncResult asyncResult)
worker_1  |    at System.Threading.Tasks.TaskFactory`1.FromAsyncCoreLogic(IAsyncResult iar, Func`2 endFunction, Action`1 endAction, Task`1 promise, Boolean requiresSynchronization)<---
```