### PR TITLE
Don't lose Redis connection on reconnect

### DIFF
--- a/worker/src/Worker/Program.cs
+++ b/worker/src/Worker/Program.cs
@@ -31,7 +31,8 @@ namespace Worker
                     // Reconnect redis if down
                     if (redisConn == null || !redisConn.IsConnected) {
                         Console.WriteLine("Reconnecting Redis");
-                        redis = OpenRedisConnection("redis").GetDatabase();
+                        redisConn = OpenRedisConnection("redis");
+                        redis = redisConn.GetDatabase();
                     }
                     string json = redis.ListLeftPopAsync("votes").Result;
                     if (json != null)


### PR DESCRIPTION
Keep Redis connection stored so that it's not lost and we avoid reconnecting all the time.
