### PR TITLE
prevent dotnet worker from consuming all cpu

### DIFF
--- a/result/Dockerfile
+++ b/result/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:5.11.0-slim
+FROM node:8.9-slim
 
 WORKDIR /app
 

--- a/result/tests/Dockerfile
+++ b/result/tests/Dockerfile
@@ -1,5 +1,11 @@
-FROM node
-RUN npm install -g phantomjs
+FROM node:8.9-slim
+RUN apt-get update -qq && apt-get install -qy \ 
+    ca-certificates \
+    bzip2 \
+    curl \
+    libfontconfig \
+    --no-install-recommends
+RUN yarn global add phantomjs-prebuilt
 ADD . /app
 WORKDIR /app
 CMD ["/app/tests.sh"]

--- a/worker/src/Worker/Program.cs
+++ b/worker/src/Worker/Program.cs
@@ -28,6 +28,9 @@ namespace Worker
                 var definition = new { vote = "", voter_id = "" };
                 while (true)
                 {
+                    // Slow down to prevent CPU spike, only query each 100ms
+                    Thread.Sleep(100);
+
                     // Reconnect redis if down
                     if (redisConn == null || !redisConn.IsConnected) {
                         Console.WriteLine("Reconnecting Redis");


### PR DESCRIPTION
*Problem:* The dotnet worker, by default, will consume a full CPU by querying redis as fast as it can, you can use `redis-cli monitor` to see dozens of LPOP's a second. This isn't great for local demos, especially when on battery.

*Solution:* add a `Thread.Sleep(100);` so it queries every 100ms max. I tested up to 500ms without any perceived delay on localhost, but 100ms still kept CPU usage quite low so I felt this was a good compromise.

This doesn't seem to be an issue with Java version, as it uses `BLPOP` to block rather than the rapid queries approach used by dotnets LPOP, which [seems to be a limitation of the chosen redis package](https://stackexchange.github.io/StackExchange.Redis/PipelinesMultiplexers) for dotnet.