### PR TITLE
updating result app node version and fixing tests

### DIFF
--- a/result/Dockerfile
+++ b/result/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:5.11.0-slim
+FROM node:8.9-slim
 
 WORKDIR /app
 

--- a/result/tests/Dockerfile
+++ b/result/tests/Dockerfile
@@ -1,5 +1,11 @@
-FROM node
-RUN npm install -g phantomjs
+FROM node:8.9-slim
+RUN apt-get update -qq && apt-get install -qy \
+    ca-certificates \
+    bzip2 \
+    curl \
+    libfontconfig \
+    --no-install-recommends
+RUN yarn global add phantomjs-prebuilt
 ADD . /app
 WORKDIR /app
 CMD ["/app/tests.sh"]


### PR DESCRIPTION
**Problem**: `result` Image won't build on Docker Hub due to failed tests using `result/docker-compose.test.yml` which uses `result/tests/Dockerfile`. That Dockerfile fails building due to outdated phantomjs install method.

**Fix**: Update test Dockerfile to use yarn for installing phantomjs.

Also: Updating result app to latest stable node.js