### PR TITLE
tests: please shellcheck

### DIFF
--- a/result/tests/tests.sh
+++ b/result/tests/tests.sh
@@ -1,14 +1,20 @@
 #!/bin/sh
-while ! timeout 1 bash -c "echo > /dev/tcp/vote/80"; do sleep 1; done
+
+while ! timeout 1 bash -c "echo > /dev/tcp/vote/80"; do
+    sleep 1
+done
+
 curl -sS -X POST --data "vote=b" http://vote > /dev/null
 sleep 10
+
 if phantomjs render.js http://result | grep -q '1 vote'; then
-  echo -e "\e[42m------------"
-  echo -e "\e[92mTests passed"
-  echo -e "\e[42m------------"
+  echo -e "\\e[42m------------"
+  echo -e "\\e[92mTests passed"
+  echo -e "\\e[42m------------"
   exit 0
-fi
-  echo -e "\e[41m------------"
-  echo -e "\e[91mTests failed"
-  echo -e "\e[41m------------"
+else
+  echo -e "\\e[41m------------"
+  echo -e "\\e[91mTests failed"
+  echo -e "\\e[41m------------"
   exit 1
+fi


### PR DESCRIPTION
Hi!

This example is run in the test suite of Docker for Mac.  We also run spellcheck on our tree.  Shellcheck now complains about misleading \-escapes in double quotes, and suggest doubling them.

While at it, I have rewritten some control flow into a more conventional layout.

Cheers!