### PR TITLE
Stay away from port 5000, used by Jenkins

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Run in this directory:
 ```
 docker-compose up
 ```
-The app will be running at [http://localhost:5000](http://localhost:5000), and the results will be at [http://localhost:5001](http://localhost:5001).
+The app will be running at [http://localhost:5100](http://localhost:5100), and the results will be at [http://localhost:5101](http://localhost:5101).
 
 Alternately, if you want to run it on a [Docker Swarm](https://docs.docker.com/engine/swarm/), first make sure you have a swarm. If you don't, run:
 ```

--- a/docker-compose-javaworker.yml
+++ b/docker-compose-javaworker.yml
@@ -7,7 +7,7 @@ services:
     volumes:
      - ./vote:/app
     ports:
-      - "5000:80"
+      - "5100:80"
     networks:
       - front-tier
       - back-tier
@@ -18,7 +18,7 @@ services:
     volumes:
       - ./result:/app
     ports:
-      - "5001:80"
+      - "5101:80"
       - "5858:5858"
     networks:
       - front-tier

--- a/docker-compose-simple.yml
+++ b/docker-compose-simple.yml
@@ -7,7 +7,7 @@ services:
     volumes:
      - ./vote:/app
     ports:
-      - "5000:80"
+      - "5100:80"
 
   redis:
     image: redis:alpine
@@ -25,5 +25,5 @@ services:
     volumes:
       - ./result:/app
     ports:
-      - "5001:80"
+      - "5101:80"
       - "5858:5858"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     volumes:
      - ./vote:/app
     ports:
-      - "5000:80"
+      - "5100:80"
     networks:
       - front-tier
       - back-tier
@@ -18,7 +18,7 @@ services:
     volumes:
       - ./result:/app
     ports:
-      - "5001:80"
+      - "5101:80"
       - "5858:5858"
     networks:
       - front-tier

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -26,7 +26,7 @@ services:
   vote:
     image: dockersamples/examplevotingapp_vote:before
     ports:
-      - 5000:80
+      - 5100:80
     networks:
       - frontend
     depends_on:
@@ -40,7 +40,7 @@ services:
   result:
     image: dockersamples/examplevotingapp_result:before
     ports:
-      - 5001:80
+      - 5101:80
     networks:
       - backend
     depends_on:


### PR DESCRIPTION
When importing this example in Docker for Mac, we have to change the port, because it's already used by Jenkins.  Sure, we have adapted to it so this change is not needed.  But it might be simpler for other people to avoid that trap upstream?

Cheers!