### PR TITLE
Fix javaworker result service not starting

### DIFF
--- a/docker-compose-javaworker.yml
+++ b/docker-compose-javaworker.yml
@@ -14,7 +14,7 @@ services:
 
   result:
     build: ./result
-    command: nodemon --debug server.js
+    command: nodemon server.js
     volumes:
       - ./result:/app
     ports:


### PR DESCRIPTION
The `--debug` option is deprecated and caused the result
service to not start:

    result_1  | [nodemon] 1.14.7
    result_1  | [nodemon] to restart at any time, enter `rs`
    result_1  | [nodemon] watching: *.*
    result_1  | [nodemon] starting `node --debug server.js`
    result_1  | (node:20) [DEP0062] DeprecationWarning: `node --debug` and `node --debug-brk` are invalid. Please use `node --inspect` or `node --inspect-brk` instead.
    result_1  | [nodemon] app crashed - waiting for file changes before starting...

This patch removes the `--debug` option, as it's not needed,
and no longer present in the other example stacks.

Same fix as https://github.com/dockersamples/example-voting-app/pull/95, but for the javaworker example



ping @ManoMarks 