### PR TITLE
Optimize result image

### DIFF
--- a/result/Dockerfile
+++ b/result/Dockerfile
@@ -1,14 +1,16 @@
-FROM node:8.9-slim
+FROM node:8.9-alpine
 
+RUN mkdir -p /app
 WORKDIR /app
 
 RUN npm install -g nodemon
-ADD package.json /app/package.json
-RUN npm config set registry http://registry.npmjs.org
-RUN npm install && npm ls
-RUN mv /app/node_modules /node_modules
-
-ADD . /app
+RUN npm config set registry https://registry.npmjs.org
+COPY package.json /app/package.json
+RUN npm install \
+ && npm ls \
+ && npm cache clean --force \
+ && mv /app/node_modules /node_modules
+COPY . /app
 
 ENV PORT 80
 EXPOSE 80


### PR DESCRIPTION
This patch makes some optimizations in the result service's image;

- switch to `node:8.9-alpine`, which a smaller base image
- use `https://` for the registry
- use `COPY` instead of `ADD`, following best pracice
- cleanup npm cache, and combine steps to reduce image size

These changes bring down the image size from 248MB to 81.2MB

ping @ManoMarks @BretFisher PTAL