### PR TITLE
Optimize java-worker image

### DIFF
--- a/worker/Dockerfile.j
+++ b/worker/Dockerfile.j
@@ -1,19 +1,17 @@
-FROM java:openjdk-8-jdk-alpine
-
-RUN MAVEN_VERSION=3.3.3 \
- && cd /usr/share \
- && wget http://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz -O - | tar xzf - \
- && mv /usr/share/apache-maven-$MAVEN_VERSION /usr/share/maven \
- && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+FROM maven:3.5-jdk-8-alpine AS build
 
 WORKDIR /code
 
-ADD pom.xml /code/pom.xml
+COPY pom.xml /code/pom.xml
 RUN ["mvn", "dependency:resolve"]
 RUN ["mvn", "verify"]
 
 # Adding source, compile and package into a fat jar
-ADD src/main /code/src/main
+COPY ["src/main", "/code/src/main"]
 RUN ["mvn", "package"]
 
-CMD ["java", "-jar", "target/worker-jar-with-dependencies.jar"]
+FROM openjdk:8-jre-alpine
+
+COPY --from=build /code/target/worker-jar-with-dependencies.jar /
+
+CMD ["java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-jar", "/worker-jar-with-dependencies.jar"]


### PR DESCRIPTION
This patch optimizes the java-worker image;

- Use multi-stage build to separate the build-stage from the "deploy" stage
- Switch to the official Maven image, instead of manual installation of Maven.
  The official Maven image is also based on the `openjdk` repository on Docker
  Hub, which replaces the (now deprecated) `java` repository.
- Use `COPY` instead of `ADD` to follow best-practice
- Add `-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap` arguments
  so that JAVA will take memory-limits into account
- Use a JRE base image for the final build-stage

This change brings the size of the final image down from 184MB to 87MB

ping @ManoMarks PTAL