### PR TITLE
Upgrade worker to dotnet 2.1, use multistage build

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.0.0-sdk
+FROM microsoft/dotnet:2.1-sdk-alpine AS build
 
 WORKDIR /code
 
@@ -7,4 +7,10 @@ ADD src/Worker /code/src/Worker
 RUN dotnet restore -v minimal src/Worker \
     && dotnet publish -c Release -o "./" "src/Worker/" 
 
-CMD dotnet src/Worker/Worker.dll
+FROM microsoft/dotnet:2.1-runtime-alpine
+
+WORKDIR /code
+
+COPY --from=build /code/src/Worker .
+
+CMD dotnet Worker.dll

--- a/worker/src/Worker/Worker.csproj
+++ b/worker/src/Worker/Worker.csproj
@@ -1,19 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>Worker</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Worker</PackageId>
     <ServerGarbageCollection>true</ServerGarbageCollection>
-    <RuntimeFrameworkVersion>2.0.0</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>2.1.0</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="StackExchange.Redis" Version="1.1.604-alpha" />
-    <PackageReference Include="Npgsql" Version="3.1.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="StackExchange.Redis" Version="1.2.6" />
+    <PackageReference Include="Npgsql" Version="4.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Upgrade worker to Dot net core 2.1 and his dependencies.

Also use multistage build and alpine images to reduce final image size from 1.49GB to 87.9MB