### PR TITLE
Remove published swarm stack redis port

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -3,8 +3,6 @@ services:
 
   redis:
     image: redis:alpine
-    ports:
-      - "6379"
     networks:
       - frontend
     deploy:


### PR DESCRIPTION
Fixes #108

In docker-compose.yml and other "designed for development" yaml files, It's typical to publish database and key/value ports for localhost access. However, it's not necessary to publish the redis port in swarm server-based solutions.