### PR TITLE
ignore node_modules in git and docker build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ project.lock.json
 bin/
 obj/
 .vs/
+node_modules/

--- a/result/.dockerignore
+++ b/result/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/


### PR DESCRIPTION
What I did:

- added `node_modules/` to `.gitignore` so npm dependencies wouldn't be added to git commits.
- added `node_modules/` to `result/.dockerignore` to prevent unnecessary `result` image bloat