### PR TITLE
fix worker compose depends_on

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       context: ./worker
     depends_on:
       - "redis"
+      - "db"
     networks:
       - back-tier
 

--- a/docker-stack-simple.yml
+++ b/docker-stack-simple.yml
@@ -58,6 +58,9 @@ services:
     networks:
       - frontend
       - backend
+    depends_on:
+      - db
+      - redis
     deploy:
       mode: replicated
       replicas: 1

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -56,6 +56,9 @@ services:
     networks:
       - frontend
       - backend
+    depends_on:
+      - db
+      - redis
     deploy:
       mode: replicated
       replicas: 1


### PR DESCRIPTION
There was inconsistency in the `worker` compose yaml for `depends_on`. The `worker` requires both `db` and `redis`, and in the default `docker-compose.yml` it was missing `db`, causing `worker` to crash on `docker-compose up`. In two other compose files for stacks, where `depends_on` was used for other services, I added it for the `worker` to match.