### PR TITLE
Temp PR to test if slim fixes npm+alpine bug

### DIFF
--- a/result/Dockerfile
+++ b/result/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.9-alpine
+FROM node:8.9-slim
 
 RUN mkdir -p /app
 WORKDIR /app


### PR DESCRIPTION
### Don't merge. Only used to test Docker's Jenkins PR builder

Related to PR #135, there's been a long-standing on-and-off again bug with npm+alpine (and sometimes Debian) and the `nobody` uid bug.  

https://github.com/npm/uid-number/issues/7 references that this is fixed for good in npm 6.11 but until we can get that in upstream images, I'm going to try a few fixes myself in this PR to see if they build with Docker's Jenkins PR builder.
