### PR TITLE
update Kubernetes manifests to app/v1 and yaml parity

### DIFF
--- a/k8s-specifications/db-deployment.yaml
+++ b/k8s-specifications/db-deployment.yaml
@@ -1,10 +1,15 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    app: db
   name: db
   namespace: vote
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: db
   template:
     metadata:
       labels:
@@ -12,7 +17,10 @@ spec:
     spec:
       containers:
       - image: postgres:9.4
-        name: db
+        name: postgres
+        ports:
+        - containerPort: 5432
+          name: postgres
         volumeMounts:
         - mountPath: /var/lib/postgresql/data
           name: db-data

--- a/k8s-specifications/db-service.yaml
+++ b/k8s-specifications/db-service.yaml
@@ -1,12 +1,15 @@
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    app: db
   name: db
   namespace: vote
 spec:
   type: ClusterIP
   ports:
-  - port: 5432
+  - name: "db-service"
+    port: 5432
     targetPort: 5432
   selector:
     app: db

--- a/k8s-specifications/redis-deployment.yaml
+++ b/k8s-specifications/redis-deployment.yaml
@@ -1,10 +1,15 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    app: redis
   name: redis
   namespace: vote
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: redis
   template:
     metadata:
       labels:
@@ -13,6 +18,9 @@ spec:
       containers:
       - image: redis:alpine
         name: redis
+        ports:
+        - containerPort: 6379
+          name: redis
         volumeMounts:
         - mountPath: /data
           name: redis-data

--- a/k8s-specifications/redis-service.yaml
+++ b/k8s-specifications/redis-service.yaml
@@ -1,12 +1,15 @@
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    app: redis
   name: redis
   namespace: vote
 spec:
   type: ClusterIP
   ports:
-  - port: 6379
+  - name: "redis-service"
+    port: 6379
     targetPort: 6379
   selector:
     app: redis

--- a/k8s-specifications/result-deployment.yaml
+++ b/k8s-specifications/result-deployment.yaml
@@ -1,10 +1,15 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    app: result
   name: result
   namespace: vote
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: result
   template:
     metadata:
       labels:
@@ -13,3 +18,6 @@ spec:
       containers:
       - image: dockersamples/examplevotingapp_result:before
         name: result
+        ports:
+        - containerPort: 80
+          name: result

--- a/k8s-specifications/result-service.yaml
+++ b/k8s-specifications/result-service.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    app: result
   name: result
   namespace: vote
 spec:

--- a/k8s-specifications/vote-deployment.yaml
+++ b/k8s-specifications/vote-deployment.yaml
@@ -1,10 +1,15 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    app: vote
   name: vote
   namespace: vote
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: vote
   template:
     metadata:
       labels:
@@ -13,3 +18,6 @@ spec:
       containers:
       - image: dockersamples/examplevotingapp_vote:before
         name: vote
+        ports:
+        - containerPort: 80
+          name: vote

--- a/k8s-specifications/vote-service.yaml
+++ b/k8s-specifications/vote-service.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    app: vote
   name: vote
   namespace: vote
 spec:

--- a/k8s-specifications/worker-deployment.yaml
+++ b/k8s-specifications/worker-deployment.yaml
@@ -1,10 +1,15 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    app: worker
   name: worker
   namespace: vote
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: db
   template:
     metadata:
       labels:

--- a/kube-deployment.yml
+++ b/kube-deployment.yml
@@ -1,3 +1,4 @@
+# redis
 --- 
 apiVersion: v1
 kind: Service
@@ -8,23 +9,23 @@ metadata:
 spec: 
   clusterIP: None
   ports:
-    - name: redis
-      port: 6379
-      targetPort: 6379
+  - name: redis-service
+    port: 6379
+    targetPort: 6379
   selector: 
     app: redis
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redis
   labels:
     app: redis
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app: redis
-  replicas: 1
   template:
     metadata:
       labels:
@@ -37,6 +38,7 @@ spec:
         - containerPort: 6379
           name: redis
 
+# db
 --- 
 apiVersion: v1
 kind: Service
@@ -47,43 +49,44 @@ metadata:
 spec: 
   clusterIP: None
   ports: 
-    - 
-      name: db
-      port: 5432
-      targetPort: 5432
+  - name: db
+    port: 5432
+    targetPort: 5432
   selector: 
     app: db
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: db
-  # labels:
-  #   app: db
+  labels:
+    app: db
 spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: db
   template:
     metadata:
       labels:
         app: db
     spec:
       containers:
-        - 
+      - name: db
+        image: postgres:9.4
+        env:
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
+        ports:
+        - containerPort: 5432
           name: db
-          image: postgres:9.4
-          env:
-            - name: PGDATA
-              value: /var/lib/postgresql/data/pgdata
-          ports:
-            - containerPort: 5432
-              name: db
-          volumeMounts:
-            - name: db-data
-              mountPath: /var/lib/postgresql/data
-      volumes:
+        volumeMounts:
         - name: db-data
-          persistentVolumeClaim:
-            claimName: postgres-pv-claim
-
+          mountPath: /var/lib/postgresql/data
+      volumes:
+      - name: db-data
+        persistentVolumeClaim:
+          claimName: postgres-pv-claim
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -96,6 +99,7 @@ spec:
     requests:
       storage: 1Gi
 
+# result
 ---
 apiVersion: v1
 kind: Service
@@ -106,15 +110,13 @@ metadata:
 spec:
   type: LoadBalancer
   ports:
-    - 
-      port: 5001
-      targetPort: 80
-      name: result
+  - port: 5001
+    targetPort: 80
+    name: result-service
   selector:
     app: result
-  # clusterIP: None
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: result
@@ -122,6 +124,9 @@ metadata:
     app: result
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: result
   template:
     metadata:
       labels:
@@ -134,6 +139,7 @@ spec:
         - containerPort: 80
           name: result
 
+# vote
 ---
 apiVersion: v1
 kind: Service
@@ -146,12 +152,11 @@ spec:
   ports:
     - port: 5000
       targetPort: 80
-      name: vote
+      name: vote-service
   selector:
     app: vote
-  # clusterIP: None
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: vote
@@ -159,19 +164,22 @@ metadata:
     app: vote
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: vote
   template:
     metadata:
       labels:
         app: vote
     spec:
       containers:
-        - name: vote
-          image: dockersamples/examplevotingapp_vote:before
-          ports:
-            - 
-              containerPort: 80
-              name: vote
-              
+      - name: vote
+        image: dockersamples/examplevotingapp_vote:before
+        ports:
+        - containerPort: 80
+          name: vote
+
+# worker
 --- 
 apiVersion: v1
 kind: Service
@@ -184,7 +192,7 @@ spec:
   selector: 
     app: worker
 --- 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata: 
   labels: 
@@ -192,12 +200,14 @@ metadata:
   name: worker
 spec: 
   replicas: 1
+  selector:
+    matchLabels:
+      app: worker
   template: 
     metadata: 
       labels: 
         app: worker
     spec: 
       containers: 
-        - 
-          image: dockersamples/examplevotingapp_worker
-          name: worker
+      - image: dockersamples/examplevotingapp_worker
+        name: worker


### PR DESCRIPTION
I've updated all Kubernetes yaml with the following benefits:

- Update yaml to current deployment manifest defaults (app/v1)
- Added container spec ports for better introspection
- Tried to reach parity between `kube-deployment.yml` and `k8s-specifications/*`
- Added some service comments to `kube-deployment.yml` to break up the large file

Note that it's undocumented, but I believe that `kube-deployment.yml` is designed for Docker Desktop where LoadBalancer works via `localhost` and PersistentVolumeClaim works with local docker volumes, and that `k8s-specifications/*` is more generic and only uses NodePort and no claims... but I could be wrong.