### PR TITLE
Fix .NET Core images

### DIFF
--- a/docker-compose-windows-1809.yml
+++ b/docker-compose-windows-1809.yml
@@ -3,7 +3,7 @@ version: "3.2"
 services:
   vote:
     image: dockersamples/examplevotingapp_vote:dotnet-nanoserver-1809
-    build: 
+    build:
       context: ./vote/dotnet
       dockerfile: Dockerfile.1809
     ports:
@@ -13,12 +13,12 @@ services:
 
   result:
     image: dockersamples/examplevotingapp_result:dotnet-nanoserver-1809
-    build: 
+    build:
       context: ./result/dotnet
       dockerfile: Dockerfile.1809
     ports:
       - "5001:80"
-    environment:      
+    environment:
       - "ConnectionStrings:ResultData=Server=db;Port=4000;Database=votes;User=root;SslMode=None"
     depends_on:
       - db
@@ -28,14 +28,14 @@ services:
     build:
       context: ./worker/dotnet
       dockerfile: Dockerfile.1809
-    environment:      
+    environment:
       - "ConnectionStrings:VoteData=Server=db;Port=4000;Database=votes;User=root;SslMode=None"
     depends_on:
       - message-queue
       - db
 
   message-queue:
-    image: dockersamples/nats:nanoserver-1809
+    image: nats:2.0.4
 
   db:
     image: dockersamples/tidb:nanoserver-1809

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - back-tier
 
   redis:
-    image: redis:alpine
+    image: redis:5.0-alpine3.10
     container_name: redis
     ports: ["6379"]
     networks:

--- a/result/dotnet/Dockerfile.1809
+++ b/result/dotnet/Dockerfile.1809
@@ -1,4 +1,4 @@
-FROM  microsoft/dotnet:2.1-sdk-nanoserver-1809 as builder
+FROM  mcr.microsoft.com/dotnet/core/sdk:2.1 as builder
 
 WORKDIR /Result
 COPY Result/Result.csproj .
@@ -8,7 +8,7 @@ COPY /Result .
 RUN dotnet publish -c Release -o /out Result.csproj
 
 # app image
-FROM microsoft/dotnet:2.1-aspnetcore-runtime-nanoserver-1809
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.1
 
 WORKDIR /app
 ENTRYPOINT ["dotnet", "Result.dll"]

--- a/vote/dotnet/Dockerfile.1809
+++ b/vote/dotnet/Dockerfile.1809
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.1-sdk-nanoserver-1809 as builder
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1 as builder
 
 WORKDIR /Vote
 COPY Vote/Vote.csproj .
@@ -8,7 +8,7 @@ COPY /Vote .
 RUN dotnet publish -c Release -o /out Vote.csproj
 
 # app image
-FROM microsoft/dotnet:2.1-aspnetcore-runtime-nanoserver-1809
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.1
 
 WORKDIR /app
 ENTRYPOINT ["dotnet", "Vote.dll"]

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,10 +1,16 @@
-FROM microsoft/dotnet:2.0.0-sdk
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1 as builder
 
-WORKDIR /code
+WORKDIR /Worker
+COPY src/Worker/Worker.csproj .
+RUN dotnet restore
 
-ADD src/Worker /code/src/Worker
+COPY src/Worker/ .
+RUN dotnet publish -c Release -o /out Worker.csproj
 
-RUN dotnet restore -v minimal src/Worker \
-    && dotnet publish -c Release -o "./" "src/Worker/" 
+# app image
+FROM mcr.microsoft.com/dotnet/core/runtime:2.1
 
-CMD dotnet src/Worker/Worker.dll
+WORKDIR /app
+ENTRYPOINT ["dotnet", "Worker.dll"]
+
+COPY --from=builder /out .

--- a/worker/dotnet/Dockerfile.1809
+++ b/worker/dotnet/Dockerfile.1809
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.1-sdk-nanoserver-1809 as builder
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1 as builder
 
 WORKDIR /Worker
 COPY Worker/Worker.csproj .
@@ -8,7 +8,7 @@ COPY /Worker .
 RUN dotnet publish -c Release -o /out Worker.csproj
 
 # app image
-FROM microsoft/dotnet:2.1-aspnetcore-runtime-nanoserver-1809
+FROM mcr.microsoft.com/dotnet/core/runtime:2.1
 
 WORKDIR /app
 ENTRYPOINT ["dotnet", "Worker.dll"]

--- a/worker/src/Worker/Worker.csproj
+++ b/worker/src/Worker/Worker.csproj
@@ -1,19 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <AssemblyName>Worker</AssemblyName>
     <OutputType>Exe</OutputType>
-    <PackageId>Worker</PackageId>
-    <ServerGarbageCollection>true</ServerGarbageCollection>
-    <RuntimeFrameworkVersion>2.0.0</RuntimeFrameworkVersion>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="StackExchange.Redis" Version="1.1.604-alpha" />
-    <PackageReference Include="Npgsql" Version="3.1.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="StackExchange.Redis" Version="2.0.601" />
+    <PackageReference Include="Npgsql" Version="4.0.9" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Updates all the .NET Core components to 2.1 and uses the SDK and runtime images from MCR.