### PR TITLE
Incorrect label for worker Deployment in .spec.selector.matchLabels

### DIFF
--- a/k8s-specifications/worker-deployment.yaml
+++ b/k8s-specifications/worker-deployment.yaml
@@ -9,7 +9,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: db
+      app: worker
   template:
     metadata:
       labels:


### PR DESCRIPTION
This prevent the creation of the worker's Deployment.