### PR TITLE
Update worker to use .NET Core 2.1

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,10 +1,19 @@
-FROM microsoft/dotnet:2.0.0-sdk
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1 AS build
 
 WORKDIR /code
 
-ADD src/Worker /code/src/Worker
+# copy csproj and restore as distinct layers
+COPY src/Worker/*.csproj ./
+RUN dotnet restore
 
-RUN dotnet restore -v minimal src/Worker \
-    && dotnet publish -c Release -o "./" "src/Worker/" 
+# copy everything else and build app
+COPY src/Worker/. ./
+RUN dotnet publish -c Release -o out
 
-CMD dotnet src/Worker/Worker.dll
+FROM mcr.microsoft.com/dotnet/core/runtime:2.1
+
+WORKDIR /app
+
+COPY --from=build /code/out ./
+
+ENTRYPOINT ["dotnet", "Worker.dll"]

--- a/worker/src/Worker/Worker.csproj
+++ b/worker/src/Worker/Worker.csproj
@@ -11,9 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="StackExchange.Redis" Version="1.1.604-alpha" />
-    <PackageReference Include="Npgsql" Version="3.1.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="StackExchange.Redis" Version="2.0.601" />
+    <PackageReference Include="Npgsql" Version="4.0.10" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
 
 </Project>

--- a/worker/src/Worker/Worker.csproj
+++ b/worker/src/Worker/Worker.csproj
@@ -1,13 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>Worker</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Worker</PackageId>
     <ServerGarbageCollection>true</ServerGarbageCollection>
-    <RuntimeFrameworkVersion>2.0.0</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The worker app uses .NET Core 2.0 which reached end of support at October 1, 2018 according to Microsoft's [.NET Core Support Policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-core).

.NET Core 2.1 is an LTS version which will be supported until at least August 21, 2021.

This PR updates the worker .NET Core project to version 2.1 of the framework and the latest stable versions of its required NuGet packages.

The updates to the Worker Dockerfile are based on Microsoft's [.NET Core Docker tutorial](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/docker/building-net-docker-images?view=aspnetcore-2.1).

The worker container builds and runs as expected on Docker Desktop for Windows 2.1.0.4.