### PR TITLE
Set an explicit username and password for the db service

### DIFF
--- a/docker-compose-javaworker.yml
+++ b/docker-compose-javaworker.yml
@@ -41,6 +41,9 @@ services:
   db:
     image: postgres:9.4
     container_name: db
+    environment:
+      POSTGRES_USER: "postgres"
+      POSTGRES_PASSWORD: "postgres"
     volumes:
       - "db-data:/var/lib/postgresql/data"
     networks:

--- a/docker-compose-k8s.yml
+++ b/docker-compose-k8s.yml
@@ -7,6 +7,9 @@ services:
       - "6379:6379"
   db:
     image: postgres:9.4
+    environment:
+      POSTGRES_USER: "postgres"
+      POSTGRES_PASSWORD: "postgres"
     ports:
       - "5432:5432"
   vote:

--- a/docker-compose-simple.yml
+++ b/docker-compose-simple.yml
@@ -18,6 +18,9 @@ services:
 
   db:
     image: postgres:9.4
+    environment:
+      POSTGRES_USER: "postgres"
+      POSTGRES_PASSWORD: "postgres"
 
   result:
     build: ./result

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,9 @@ services:
   db:
     image: postgres:9.4
     container_name: db
+    environment:
+      POSTGRES_USER: "postgres"
+      POSTGRES_PASSWORD: "postgres"
     volumes:
       - "db-data:/var/lib/postgresql/data"
     networks:

--- a/docker-stack-simple.yml
+++ b/docker-stack-simple.yml
@@ -16,6 +16,9 @@ services:
         condition: on-failure
   db:
     image: postgres:9.4
+    environment:
+      POSTGRES_USER: "postgres"
+      POSTGRES_PASSWORD: "postgres"
     volumes:
       - db-data:/var/lib/postgresql/data
     networks:

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -14,6 +14,9 @@ services:
         condition: on-failure
   db:
     image: postgres:9.4
+    environment:
+      POSTGRES_USER: "postgres"
+      POSTGRES_PASSWORD: "postgres"
     volumes:
       - db-data:/var/lib/postgresql/data
     networks:

--- a/k8s-specifications/db-deployment.yaml
+++ b/k8s-specifications/db-deployment.yaml
@@ -18,6 +18,11 @@ spec:
       containers:
       - image: postgres:9.4
         name: postgres
+        env:
+        - name: POSTGRES_USER
+          value: postgres
+        - name: POSTGRES_PASSWORD
+          value: postgres
         ports:
         - containerPort: 5432
           name: postgres

--- a/kube-deployment.yml
+++ b/kube-deployment.yml
@@ -77,6 +77,10 @@ spec:
         env:
         - name: PGDATA
           value: /var/lib/postgresql/data/pgdata
+        - name: POSTGRES_USER
+          value: postgres
+        - name: POSTGRES_PASSWORD
+          value: postgres
         ports:
         - containerPort: 5432
           name: db

--- a/result/docker-compose.test.yml
+++ b/result/docker-compose.test.yml
@@ -47,6 +47,9 @@ services:
 
   db:
     image: postgres:9.4
+    environment:
+      POSTGRES_USER: "postgres"
+      POSTGRES_PASSWORD: "postgres"
     volumes:
       - "db-data:/var/lib/postgresql/data"
     networks:

--- a/result/server.js
+++ b/result/server.js
@@ -24,7 +24,7 @@ io.sockets.on('connection', function (socket) {
 });
 
 var pool = new pg.Pool({
-  connectionString: 'postgres://postgres@db/postgres'
+  connectionString: 'postgres://postgres:postgres@db/postgres'
 });
 
 async.retry(

--- a/worker/src/Worker/Program.cs
+++ b/worker/src/Worker/Program.cs
@@ -16,7 +16,7 @@ namespace Worker
         {
             try
             {
-                var pgsql = OpenDbConnection("Server=db;Username=postgres;");
+                var pgsql = OpenDbConnection("Server=db;Username=postgres;Password=postgres;");
                 var redisConn = OpenRedisConnection("redis");
                 var redis = redisConn.GetDatabase();
 
@@ -46,7 +46,7 @@ namespace Worker
                         if (!pgsql.State.Equals(System.Data.ConnectionState.Open))
                         {
                             Console.WriteLine("Reconnecting DB");
-                            pgsql = OpenDbConnection("Server=db;Username=postgres;");
+                            pgsql = OpenDbConnection("Server=db;Username=postgres;Password=postgres;");
                         }
                         else
                         { // Normal +1 vote requested

--- a/worker/src/main/java/worker/Worker.java
+++ b/worker/src/main/java/worker/Worker.java
@@ -72,7 +72,7 @@ class Worker {
 
       while (conn == null) {
         try {
-          conn = DriverManager.getConnection(url, "postgres", "");
+          conn = DriverManager.getConnection(url, "postgres", "postgres");
         } catch (SQLException e) {
           System.err.println("Waiting for db");
           sleep(1000);


### PR DESCRIPTION
## Issue that this addresses

The official Postgres image pushed a change that will prevent a fresh database from initializing without a password.

Trying to start with an empty db volume results in this error from the `db` container:
```
db        | Error: Database is uninitialized and superuser password is not specified.
db        |        You must specify POSTGRES_PASSWORD for the superuser. Use
db        |        "-e POSTGRES_PASSWORD=password" to set it in "docker run".
db        |
db        |        You may also use POSTGRES_HOST_AUTH_METHOD=trust to allow all connections
db        |        without a password. This is *not* recommended. See PostgreSQL
db        |        documentation about "trust":
db        |        https://www.postgresql.org/docs/current/auth-trust.html
```

## Solution

- Explicitly set the default Postgres username and password to `postgres` via environment.
- Set the new Postgres password in each service's configuration.