### PR TITLE
Pin postgres to 9.4.24, as newer images require defined passwords

### DIFF
--- a/docker-compose-javaworker.yml
+++ b/docker-compose-javaworker.yml
@@ -39,7 +39,7 @@ services:
       - back-tier
 
   db:
-    image: postgres:9.4
+    image: postgres:9.4.24
     container_name: db
     volumes:
       - "db-data:/var/lib/postgresql/data"

--- a/docker-compose-k8s.yml
+++ b/docker-compose-k8s.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "6379:6379"
   db:
-    image: postgres:9.4
+    image: postgres:9.4.24
     ports:
       - "5432:5432"
   vote:

--- a/docker-compose-simple.yml
+++ b/docker-compose-simple.yml
@@ -17,7 +17,7 @@ services:
     build: ./worker
 
   db:
-    image: postgres:9.4
+    image: postgres:9.4.24
 
   result:
     build: ./result

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - back-tier
 
   db:
-    image: postgres:9.4
+    image: postgres:9.4.24
     container_name: db
     volumes:
       - "db-data:/var/lib/postgresql/data"

--- a/docker-stack-simple.yml
+++ b/docker-stack-simple.yml
@@ -15,7 +15,7 @@ services:
       restart_policy:
         condition: on-failure
   db:
-    image: postgres:9.4
+    image: postgres:9.4.24
     volumes:
       - db-data:/var/lib/postgresql/data
     networks:

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -13,7 +13,7 @@ services:
       restart_policy:
         condition: on-failure
   db:
-    image: postgres:9.4
+    image: postgres:9.4.24
     volumes:
       - db-data:/var/lib/postgresql/data
     networks:


### PR DESCRIPTION
The latest versions of the postgres image requires the `POSTGRES_PASSWORD` to be defined. When not defined, the container doesn't start up. This PR pins to 9.4.24, which was the last built image in the 9.4 branch before the change.