### PR TITLE
Update dotnet 3.1 (needed to support Apple Silicon M1)

### DIFF
--- a/result/dotnet/Dockerfile.1809
+++ b/result/dotnet/Dockerfile.1809
@@ -1,4 +1,4 @@
-FROM  mcr.microsoft.com/dotnet/core/sdk:2.1 as builder
+FROM  mcr.microsoft.com/dotnet/core/sdk:3.1 as builder
 
 WORKDIR /Result
 COPY Result/Result.csproj .
@@ -8,7 +8,7 @@ COPY /Result .
 RUN dotnet publish -c Release -o /out Result.csproj
 
 # app image
-FROM mcr.microsoft.com/dotnet/core/aspnet:2.1
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
 
 WORKDIR /app
 ENTRYPOINT ["dotnet", "Result.dll"]

--- a/result/dotnet/Result/Result.csproj
+++ b/result/dotnet/Result/Result.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/vote/dotnet/Dockerfile.1809
+++ b/vote/dotnet/Dockerfile.1809
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:2.1 as builder
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 as builder
 
 WORKDIR /Vote
 COPY Vote/Vote.csproj .
@@ -8,7 +8,7 @@ COPY /Vote .
 RUN dotnet publish -c Release -o /out Vote.csproj
 
 # app image
-FROM mcr.microsoft.com/dotnet/core/aspnet:2.1
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
 
 WORKDIR /app
 ENTRYPOINT ["dotnet", "Vote.dll"]

--- a/vote/dotnet/Vote/Vote.csproj
+++ b/vote/dotnet/Vote/Vote.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:2.1 as builder
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 as builder
 
 WORKDIR /Worker
 COPY src/Worker/Worker.csproj .
@@ -8,7 +8,7 @@ COPY src/Worker/ .
 RUN dotnet publish -c Release -o /out Worker.csproj
 
 # app image
-FROM mcr.microsoft.com/dotnet/core/runtime:2.1
+FROM mcr.microsoft.com/dotnet/core/runtime:3.1
 
 WORKDIR /app
 ENTRYPOINT ["dotnet", "Worker.dll"]

--- a/worker/dotnet/Dockerfile.1809
+++ b/worker/dotnet/Dockerfile.1809
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:2.1 as builder
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 as builder
 
 WORKDIR /Worker
 COPY Worker/Worker.csproj .
@@ -8,7 +8,7 @@ COPY /Worker .
 RUN dotnet publish -c Release -o /out Worker.csproj
 
 # app image
-FROM mcr.microsoft.com/dotnet/core/runtime:2.1
+FROM mcr.microsoft.com/dotnet/core/runtime:3.1
 
 WORKDIR /app
 ENTRYPOINT ["dotnet", "Worker.dll"]

--- a/worker/dotnet/Worker/Worker.csproj
+++ b/worker/dotnet/Worker/Worker.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/worker/src/Worker/Worker.csproj
+++ b/worker/src/Worker/Worker.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR updates dotnet from 2.1 to 3.1 to fix an issue that was raised on **Apple M1** mentioned in Docker Community Slack:
> Hi, I was trying to run this docker sample on my Macbook Air M1 but I get the following errors. Any thoughts on how I could fix this?
Sample - https://github.com/dockersamples/example-voting-app

<img width="773" alt="screenshot_2021-02-12_at_9 33 21_pm" src="https://user-images.githubusercontent.com/207759/107801414-537e3480-6d60-11eb-80ef-5b5b2e72574d.png">

It turns out that the dotnet 2.1 multi-arch image only supports linux/amd64 and linux/arm/v7, the newer dotnet 3.1 also has linux/arm64 in the manifest list.

I hope that doesn't break anything in the sample app. I could build and run it with a simple `docker-compose up`.

