### PR TITLE
Delete vote-namespace.yml

### DIFF
--- a/k8s-specifications/vote-namespace.yml
+++ b/k8s-specifications/vote-namespace.yml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: vote
-  


### PR DESCRIPTION
I suggest to remove the namespace deployment file. This file is aborting the deployment because "vote" namespace is manually created according to the documentation from the readme https://github.com/dockersamples/example-voting-app#readme

``
 First create the vote namespace
copy-paste of the current guide:
$ kubectl create namespace vote
Run the following command to create the deployments and services objects:

$ kubectl create -f k8s-specifications/
....
``