### PR TITLE
adding GHA for docker builds and dependabot config for GHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/call-docker-build-result.yaml
+++ b/.github/workflows/call-docker-build-result.yaml
@@ -1,0 +1,83 @@
+name: Build Result
+# template source: https://github.com/dockersamples/.github/blob/main/templates/call-docker-build.yaml
+
+on:
+  # we want pull requests so we can build(test) but not push to image registry
+  push:
+    branches:
+      - 'main'
+    # only build when important files change
+    paths:
+      - 'result/**'
+      - '.github/workflows/call-docker-build-result.yaml'
+  pull_request:
+    branches:
+      - 'main'
+    # only build when important files change
+    paths:
+      - 'result/**'
+      - '.github/workflows/call-docker-build-result.yaml'
+
+jobs:
+  call-docker-build:
+
+    name: Call Docker Build
+
+    uses: dockersamples/.github/.github/workflows/reusable-docker-build.yaml@gha-reusable-init
+
+    permissions:
+      contents: read
+      packages: write # needed to push docker image to ghcr.io
+      pull-requests: write # needed to create and update comments in PRs
+    
+    secrets:
+
+      # Only needed if with:dockerhub-enable is true below
+      dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+
+      # Only needed if with:dockerhub-enable is true below
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    with:
+      
+      ### REQUIRED
+      ### ENABLE ONE OR BOTH REGISTRIES
+      ### tell docker where to push.
+      ### NOTE if Docker Hub is set to true, you must set secrets above and also add account/repo/tags below
+      dockerhub-enable: false
+      ghcr-enable: true
+
+      ### REQUIRED 
+      ### A list of the account/repo names for docker build. List should match what's enabled above
+      ### defaults to:
+      image-names: |
+        dockersamples/examplevotingapp_result
+        ghcr.io/dockersamples/example-voting-app-result
+
+      ### REQUIRED set rules for tagging images, based on special action syntax:
+      ### https://github.com/docker/metadata-action#tags-input
+      ### defaults to:
+      tag-rules: |
+        type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
+        type=ref,event=pr
+        type=ref,event=branch
+        type=semver,pattern={{version}}
+        type=raw,value=gha-${{ github.run_id }}
+      
+      ### path to where docker should copy files into image
+      ### defaults to root of repository (.)
+      context: result
+      
+      ### Dockerfile alternate name. Default is Dockerfile (relative to context path)
+      # file: Containerfile
+
+      ### build stage to target, defaults to empty, which builds to last stage in Dockerfile
+      # target:
+      
+      ### platforms to build for, defaults to linux/amd64
+      ### other options: linux/amd64,linux/arm64,linux/arm/v7
+      platforms: linux/amd64,linux/arm64,linux/arm/v7
+      
+      ### Create a PR comment with image tags and labels
+      ### defaults to false
+      # comment-enable: false

--- a/.github/workflows/call-docker-build-result.yaml
+++ b/.github/workflows/call-docker-build-result.yaml
@@ -44,7 +44,7 @@ jobs:
       ### ENABLE ONE OR BOTH REGISTRIES
       ### tell docker where to push.
       ### NOTE if Docker Hub is set to true, you must set secrets above and also add account/repo/tags below
-      dockerhub-enable: false
+      dockerhub-enable: true
       ghcr-enable: true
 
       ### REQUIRED 

--- a/.github/workflows/call-docker-build-result.yaml
+++ b/.github/workflows/call-docker-build-result.yaml
@@ -21,9 +21,9 @@ on:
 jobs:
   call-docker-build:
 
-    name: Call Docker Build
+    name: Result Call Docker Build
 
-    uses: dockersamples/.github/.github/workflows/reusable-docker-build.yaml@gha-reusable-init
+    uses: dockersamples/.github/.github/workflows/reusable-docker-build.yaml@main
 
     permissions:
       contents: read

--- a/.github/workflows/call-docker-build-result.yaml
+++ b/.github/workflows/call-docker-build-result.yaml
@@ -51,9 +51,9 @@ jobs:
       ### A list of the account/repo names for docker build. List should match what's enabled above
       ### defaults to:
       image-names: |
-        dockersamples/examplevotingapp_result
         ghcr.io/dockersamples/example-voting-app-result
-
+      # dockersamples/examplevotingapp_result
+      
       ### REQUIRED set rules for tagging images, based on special action syntax:
       ### https://github.com/docker/metadata-action#tags-input
       ### defaults to:

--- a/.github/workflows/call-docker-build-vote.yaml
+++ b/.github/workflows/call-docker-build-vote.yaml
@@ -21,9 +21,9 @@ on:
 jobs:
   call-docker-build:
 
-    name: Call Docker Build
+    name: Vote Call Docker Build
 
-    uses: dockersamples/.github/.github/workflows/reusable-docker-build.yaml@gha-reusable-init
+    uses: dockersamples/.github/.github/workflows/reusable-docker-build.yaml@main
 
     permissions:
       contents: read

--- a/.github/workflows/call-docker-build-vote.yaml
+++ b/.github/workflows/call-docker-build-vote.yaml
@@ -44,7 +44,7 @@ jobs:
       ### ENABLE ONE OR BOTH REGISTRIES
       ### tell docker where to push.
       ### NOTE if Docker Hub is set to true, you must set secrets above and also add account/repo/tags below
-      dockerhub-enable: false
+      dockerhub-enable: true
       ghcr-enable: true
 
       ### REQUIRED 

--- a/.github/workflows/call-docker-build-vote.yaml
+++ b/.github/workflows/call-docker-build-vote.yaml
@@ -51,9 +51,9 @@ jobs:
       ### A list of the account/repo names for docker build. List should match what's enabled above
       ### defaults to:
       image-names: |
-        dockersamples/examplevotingapp_vote
         ghcr.io/dockersamples/example-voting-app-vote
-
+      # dockersamples/examplevotingapp_vote
+      
       ### REQUIRED set rules for tagging images, based on special action syntax:
       ### https://github.com/docker/metadata-action#tags-input
       ### defaults to:

--- a/.github/workflows/call-docker-build-vote.yaml
+++ b/.github/workflows/call-docker-build-vote.yaml
@@ -1,0 +1,83 @@
+name: Build Vote
+# template source: https://github.com/dockersamples/.github/blob/main/templates/call-docker-build.yaml
+
+on:
+  # we want pull requests so we can build(test) but not push to image registry
+  push:
+    branches:
+      - 'main'
+    # only build when important files change
+    paths:
+      - 'vote/**'
+      - '.github/workflows/call-docker-build-vote.yaml'
+  pull_request:
+    branches:
+      - 'main'
+    # only build when important files change
+    paths:
+      - 'vote/**'
+      - '.github/workflows/call-docker-build-vote.yaml'
+
+jobs:
+  call-docker-build:
+
+    name: Call Docker Build
+
+    uses: dockersamples/.github/.github/workflows/reusable-docker-build.yaml@gha-reusable-init
+
+    permissions:
+      contents: read
+      packages: write # needed to push docker image to ghcr.io
+      pull-requests: write # needed to create and update comments in PRs
+    
+    secrets:
+
+      # Only needed if with:dockerhub-enable is true below
+      dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+
+      # Only needed if with:dockerhub-enable is true below
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    with:
+      
+      ### REQUIRED
+      ### ENABLE ONE OR BOTH REGISTRIES
+      ### tell docker where to push.
+      ### NOTE if Docker Hub is set to true, you must set secrets above and also add account/repo/tags below
+      dockerhub-enable: false
+      ghcr-enable: true
+
+      ### REQUIRED 
+      ### A list of the account/repo names for docker build. List should match what's enabled above
+      ### defaults to:
+      image-names: |
+        dockersamples/examplevotingapp_vote
+        ghcr.io/dockersamples/example-voting-app-vote
+
+      ### REQUIRED set rules for tagging images, based on special action syntax:
+      ### https://github.com/docker/metadata-action#tags-input
+      ### defaults to:
+      # tag-rules: |
+      #   type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
+      #   type=ref,event=pr
+      #   type=ref,event=branch
+      #   type=semver,pattern={{version}}
+      #   type=raw,value=gha-${{ github.run_id }}
+      
+      ### path to where docker should copy files into image
+      ### defaults to root of repository (.)
+      context: vote
+      
+      ### Dockerfile alternate name. Default is Dockerfile (relative to context path)
+      # file: Containerfile
+
+      ### build stage to target, defaults to empty, which builds to last stage in Dockerfile
+      # target:
+      
+      ### platforms to build for, defaults to linux/amd64
+      ### other options: linux/amd64,linux/arm64,linux/arm/v7
+      platforms: linux/amd64,linux/arm64,linux/arm/v7
+      
+      ### Create a PR comment with image tags and labels
+      ### defaults to false
+      # comment-enable: false

--- a/.github/workflows/call-docker-build-worker.yaml
+++ b/.github/workflows/call-docker-build-worker.yaml
@@ -1,0 +1,83 @@
+name: Build Worker
+# template source: https://github.com/dockersamples/.github/blob/main/templates/call-docker-build.yaml
+
+on:
+  # we want pull requests so we can build(test) but not push to image registry
+  push:
+    branches:
+      - 'main'
+    # only build when important files change
+    paths:
+      - 'worker/**'
+      - '.github/workflows/call-docker-build-worker.yaml'
+  pull_request:
+    branches:
+      - 'main'
+    # only build when important files change
+    paths:
+      - 'worker/**'
+      - '.github/workflows/call-docker-build-worker.yaml'
+
+jobs:
+  call-docker-build:
+
+    name: Call Docker Build
+
+    uses: dockersamples/.github/.github/workflows/reusable-docker-build.yaml@gha-reusable-init
+
+    permissions:
+      contents: read
+      packages: write # needed to push docker image to ghcr.io
+      pull-requests: write # needed to create and update comments in PRs
+    
+    secrets:
+
+      # Only needed if with:dockerhub-enable is true below
+      dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+
+      # Only needed if with:dockerhub-enable is true below
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    with:
+      
+      ### REQUIRED
+      ### ENABLE ONE OR BOTH REGISTRIES
+      ### tell docker where to push.
+      ### NOTE if Docker Hub is set to true, you must set secrets above and also add account/repo/tags below
+      dockerhub-enable: false
+      ghcr-enable: true
+
+      ### REQUIRED 
+      ### A list of the account/repo names for docker build. List should match what's enabled above
+      ### defaults to:
+      image-names: |
+        dockersamples/examplevotingapp_worker
+        ghcr.io/dockersamples/example-voting-app-worker
+
+      ### REQUIRED set rules for tagging images, based on special action syntax:
+      ### https://github.com/docker/metadata-action#tags-input
+      ### defaults to:
+      # tag-rules: |
+      #   type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
+      #   type=ref,event=pr
+      #   type=ref,event=branch
+      #   type=semver,pattern={{version}}
+      #   type=raw,value=gha-${{ github.run_id }}
+      
+      ### path to where docker should copy files into image
+      ### defaults to root of repository (.)
+      context: worker
+      
+      ### Dockerfile alternate name. Default is Dockerfile (relative to context path)
+      # file: Containerfile
+
+      ### build stage to target, defaults to empty, which builds to last stage in Dockerfile
+      # target:
+      
+      ### platforms to build for, defaults to linux/amd64
+      ### other options: linux/amd64,linux/arm64,linux/arm/v7
+      platforms: linux/amd64,linux/arm64,linux/arm/v7
+      
+      ### Create a PR comment with image tags and labels
+      ### defaults to false
+      # comment-enable: false

--- a/.github/workflows/call-docker-build-worker.yaml
+++ b/.github/workflows/call-docker-build-worker.yaml
@@ -21,9 +21,9 @@ on:
 jobs:
   call-docker-build:
 
-    name: Call Docker Build
+    name: Worker Call Docker Build
 
-    uses: dockersamples/.github/.github/workflows/reusable-docker-build.yaml@gha-reusable-init
+    uses: dockersamples/.github/.github/workflows/reusable-docker-build.yaml@main
 
     permissions:
       contents: read

--- a/.github/workflows/call-docker-build-worker.yaml
+++ b/.github/workflows/call-docker-build-worker.yaml
@@ -44,7 +44,7 @@ jobs:
       ### ENABLE ONE OR BOTH REGISTRIES
       ### tell docker where to push.
       ### NOTE if Docker Hub is set to true, you must set secrets above and also add account/repo/tags below
-      dockerhub-enable: false
+      dockerhub-enable: true
       ghcr-enable: true
 
       ### REQUIRED 

--- a/.github/workflows/call-docker-build-worker.yaml
+++ b/.github/workflows/call-docker-build-worker.yaml
@@ -76,7 +76,9 @@ jobs:
       
       ### platforms to build for, defaults to linux/amd64
       ### other options: linux/amd64,linux/arm64,linux/arm/v7
-      platforms: linux/amd64,linux/arm64,linux/arm/v7
+      # FIXME worker arm/v7 support doesn't build in .net core 3.1 with QEMU
+      # a fix would likely run the .net build on amd64 but with a target of arm/v7
+      platforms: linux/amd64,linux/arm64
       
       ### Create a PR comment with image tags and labels
       ### defaults to false

--- a/.github/workflows/call-docker-build-worker.yaml
+++ b/.github/workflows/call-docker-build-worker.yaml
@@ -51,9 +51,9 @@ jobs:
       ### A list of the account/repo names for docker build. List should match what's enabled above
       ### defaults to:
       image-names: |
-        dockersamples/examplevotingapp_worker
         ghcr.io/dockersamples/example-voting-app-worker
-
+      # dockersamples/examplevotingapp_worker
+      
       ### REQUIRED set rules for tagging images, based on special action syntax:
       ### https://github.com/docker/metadata-action#tags-input
       ### defaults to:


### PR DESCRIPTION
This PR creates a docker build-and-push workflow for the three apps in this repo.

It uses a reusable workflow that's in the `dockersample/.github` repo.

It also adds a monthly dependabot scan for any GHA step updates.

Note that arm/v7 builds of worker (.net core 3.1) don't work with QEMU-emulated builds, so I've added a task to the [project backlog](https://github.com/orgs/dockersamples/projects/1/views/1) to redeisgn that build.