### PR TITLE
Fix dotnet build

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -3,6 +3,9 @@
 # (errors common in arm/v7 32bit) https://github.com/dotnet/dotnet-docker/issues/1537
 # https://hub.docker.com/_/microsoft-dotnet
 # hadolint ignore=DL3029
+# to build for a different platform than your host, use --platform=<platform>
+# for example, if you were on Intel (amd64) and wanted to build for ARM, you would use:
+# docker buildx build --platform "linux/arm64/v8" .
 FROM --platform=${BUILDPLATFORM} mcr.microsoft.com/dotnet/sdk:7.0 as build
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
@@ -13,6 +16,7 @@ COPY *.csproj .
 RUN case ${TARGETPLATFORM} in \
          "linux/amd64")  ARCH=x64  ;; \
          "linux/arm64")  ARCH=arm64  ;; \
+         "linux/arm64/v8")  ARCH=arm64  ;; \
          "linux/arm/v7") ARCH=arm  ;; \
     esac \
     && dotnet restore -r linux-${ARCH}
@@ -21,6 +25,7 @@ COPY . .
 RUN  case ${TARGETPLATFORM} in \
          "linux/amd64")  ARCH=x64  ;; \
          "linux/arm64")  ARCH=arm64  ;; \
+         "linux/arm64/v8")  ARCH=arm64  ;; \
          "linux/arm/v7") ARCH=arm  ;; \
     esac \
     && dotnet publish -c release -o /app -r linux-${ARCH} --self-contained false --no-restore


### PR DESCRIPTION
Various platforms report different TARGETPLATFORM to Docker. Previously, builds might fail on an arm64 machine if it reported `linux/arm64/v8` to BuildKit. This fixes that.
