### PR TITLE
Remove namespace from k8s example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ kubectl create -f k8s-specifications/
 
 The `vote` web app is then available on port 31000 on each host of the cluster, the `result` web app is available on port 31001.
 
+To remove them, run:
+
+```shell
+kubectl delete -f k8s-specifications/
+```
+
 ## Architecture
 
 ![Architecture diagram](architecture.png)

--- a/README.md
+++ b/README.md
@@ -32,24 +32,13 @@ docker stack deploy --compose-file docker-stack.yml vote
 
 The folder k8s-specifications contains the YAML specifications of the Voting App's services.
 
-Run the following command to create the deployments and services objects in the vote namespace:
+Run the following command to create the deployments and services. Note it will create these resources in your current namespace (`default` if you haven't changed it.)
 
 ```shell
 kubectl create -f k8s-specifications/
-vote "vote" created
-deployment "db" created
-deployment "db" created
-service "db" created
-deployment "redis" created
-service "redis" created
-deployment "result" created
-service "result" created
-deployment "vote" created
-service "vote" created
-deployment "worker" created
 ```
 
-The vote interface is then available on port 31000 on each host of the cluster, the result one is available on port 31001.
+The `vote` web app is then available on port 31000 on each host of the cluster, the `result` web app is available on port 31001.
 
 ## Architecture
 

--- a/k8s-specifications/db-deployment.yaml
+++ b/k8s-specifications/db-deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     app: db
   name: db
-  namespace: vote
 spec:
   replicas: 1
   selector:

--- a/k8s-specifications/db-service.yaml
+++ b/k8s-specifications/db-service.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     app: db
   name: db
-  namespace: vote
 spec:
   type: ClusterIP
   ports:

--- a/k8s-specifications/redis-deployment.yaml
+++ b/k8s-specifications/redis-deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     app: redis
   name: redis
-  namespace: vote
 spec:
   replicas: 1
   selector:

--- a/k8s-specifications/redis-service.yaml
+++ b/k8s-specifications/redis-service.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     app: redis
   name: redis
-  namespace: vote
 spec:
   type: ClusterIP
   ports:

--- a/k8s-specifications/result-deployment.yaml
+++ b/k8s-specifications/result-deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     app: result
   name: result
-  namespace: vote
 spec:
   replicas: 1
   selector:

--- a/k8s-specifications/result-service.yaml
+++ b/k8s-specifications/result-service.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     app: result
   name: result
-  namespace: vote
 spec:
   type: NodePort
   ports:

--- a/k8s-specifications/vote-deployment.yaml
+++ b/k8s-specifications/vote-deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     app: vote
   name: vote
-  namespace: vote
 spec:
   replicas: 1
   selector:

--- a/k8s-specifications/vote-namespace.yml
+++ b/k8s-specifications/vote-namespace.yml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: vote
-  

--- a/k8s-specifications/vote-service.yaml
+++ b/k8s-specifications/vote-service.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     app: vote
   name: vote
-  namespace: vote
 spec:
   type: NodePort
   ports:

--- a/k8s-specifications/worker-deployment.yaml
+++ b/k8s-specifications/worker-deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     app: worker
   name: worker
-  namespace: vote
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
This is debatable, but I find it easier to avoid mandating or creating namespaces in simple K8s examples. We can't assume they know namespace basics, how to switch namespaces etc.  Local dev setups like Docker Desktop are fine with demos going in `default`.

This PR is to remove all references to the vote namespace in manifests, and it'll just create the resources in your current namespace.

I've also updated the docs to reflect that, which I think will work better for people using this repo to get started with Docker and K8s.