### PR TITLE
Adding a git attributes file to avoid EOL issues

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Set default behavior to automatically normalize line endings.
+* text=auto
+
+# Force batch scripts to always use CRLF line endings so that if a repo is accessed
+# in Windows via a file share from Linux, the scripts will work.
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf
+*.{ics,[iI][cC][sS]} text eol=crlf
+
+# Force bash scripts to always use LF line endings so that if a repo is accessed
+# in Unix via a file share from Windows, the scripts will work.
+*.sh text eol=lf


### PR DESCRIPTION
CRLF in .sh healthcheck scripts seems to causes failures.
git clone with default parameters on Windows would change all line endings to CRLF.
The .gitattributes file makes sure the LF line endings are preserved for .sh files.