### PR TITLE
Simplify .NET multi-platform Dockerfile

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -8,30 +8,19 @@
 # docker buildx build --platform "linux/arm64/v8" .
 FROM --platform=${BUILDPLATFORM} mcr.microsoft.com/dotnet/sdk:7.0 as build
 ARG TARGETPLATFORM
+ARG TARGETARCH
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
 WORKDIR /source
 COPY *.csproj .
-RUN case ${TARGETPLATFORM} in \
-         "linux/amd64")  ARCH=x64  ;; \
-         "linux/arm64")  ARCH=arm64  ;; \
-         "linux/arm64/v8")  ARCH=arm64  ;; \
-         "linux/arm/v7") ARCH=arm  ;; \
-    esac \
-    && dotnet restore -r linux-${ARCH}
+RUN dotnet restore -a $TARGETARCH
 
 COPY . .
-RUN  case ${TARGETPLATFORM} in \
-         "linux/amd64")  ARCH=x64  ;; \
-         "linux/arm64")  ARCH=arm64  ;; \
-         "linux/arm64/v8")  ARCH=arm64  ;; \
-         "linux/arm/v7") ARCH=arm  ;; \
-    esac \
-    && dotnet publish -c release -o /app -r linux-${ARCH} --self-contained false --no-restore
+RUN dotnet publish -c release -o /app -a $TARGETARCH --self-contained false --no-restore
 
 # app image
-FROM mcr.microsoft.com/dotnet/runtime:7.0
+FROM --platform=${TARGETPLATFORM} mcr.microsoft.com/dotnet/runtime:7.0
 WORKDIR /app
 COPY --from=build /app .
 ENTRYPOINT ["dotnet", "Worker.dll"]

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -20,7 +20,7 @@ COPY . .
 RUN dotnet publish -c release -o /app -a $TARGETARCH --self-contained false --no-restore
 
 # app image
-FROM --platform=${TARGETPLATFORM} mcr.microsoft.com/dotnet/runtime:7.0
+FROM mcr.microsoft.com/dotnet/runtime:7.0
 WORKDIR /app
 COPY --from=build /app .
 ENTRYPOINT ["dotnet", "Worker.dll"]


### PR DESCRIPTION
Since .NET 7.0.300, the new `-a/--arch` argument is supported that accepts the same formatting as Docker's $TARGETARCH. This greatly simplifies the restore and build commands in this sample.

See @richlander's [blog post](https://devblogs.microsoft.com/dotnet/improving-multiplatform-container-support/) and https://github.com/dotnet/sdk/issues/30369 for more context.