### PR TITLE
Add debug port support for the results (node) app

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Note: Results debugger",
+      "type": "node",
+      "request": "attach",
+      "port": 9229,
+      "address": "localhost",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "remoteRoot": "/app",
+      "localRoot": "${workspaceFolder}/result"
+    }
+  ]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
   result:
     build: ./result
     # use nodemon rather than node for local dev
-    entrypoint: nodemon server.js
+    entrypoint: nodemon --inspect-brk=0.0.0.0 server.js
     depends_on:
       db:
         condition: service_healthy 
@@ -35,7 +35,7 @@ services:
       - ./result:/app
     ports:
       - "5001:80"
-      - "5858:5858"
+      - "9229:9229"
     networks:
       - front-tier
       - back-tier


### PR DESCRIPTION
Simply adds debug support for the results service, making it possible to set breakpoints and debug the node app