### PR TITLE
fix '/seed/generate-votes.sh: not found' Error

### DIFF
--- a/seed-data/Dockerfile
+++ b/seed-data/Dockerfile
@@ -13,4 +13,4 @@ COPY . .
 # create POST data files with ab friendly formats
 RUN python make-data.py
 
-CMD /seed/generate-votes.sh
+CMD bash /seed/generate-votes.sh


### PR DESCRIPTION
This pull request addresses the issue where the initial CMD instruction in the Dockerfile was causing **/bin/sh: 1: /seed/generate-votes.sh: not found** Error.

### Changes Made

Updated Dockerfile under /seed-data directory to use `CMD bash /seed/generate-votes.sh` for proper script execution.

### Testing
Manually tested the Docker build with the modified Dockerfile.
Verified that the /seed/generate-votes.sh script runs without errors inside the Docker container.