### PR TITLE
Add .dockerignore to worker, fixes #349

### DIFF
--- a/worker/.dockerignore
+++ b/worker/.dockerignore
@@ -1,0 +1,12 @@
+.dockerignore
+.env
+.git
+.gitignore
+.vs
+.vscode
+docker-compose.yml
+docker-compose.*.yml
+**/bin
+**/obj
+bin/
+obj/


### PR DESCRIPTION
As described in #349 docker compose up fails because of bin/obj folders beeing included, the .dockerignore fixes this issue