### PR TITLE
Optimize: worker-deployment.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 A simple distributed application running across multiple Docker containers.
 
+> [!NOTE]
+> This repo is a fork of example voting app by Docker, we have made some changes to the manifests so that it can be used as a sample app for the Kubernetes Application troubleshooting video.
+> There are some intentional errors introduced in the application to demo the application troubleshooting scenario for a simple web app
+
+
 ## Getting started
 
 Download [Docker Desktop](https://www.docker.com/products/docker-desktop) for Mac or Windows. [Docker Compose](https://docs.docker.com/compose) will be automatically installed. On Linux, make sure you have the latest version of [Compose](https://docs.docker.com/compose/install/).
@@ -56,10 +61,17 @@ kubectl delete -f k8s-specifications/
 * A [Postgres](https://hub.docker.com/_/postgres/) database backed by a Docker volume
 * A [Node.js](/result) web app which shows the results of the voting in real time
 
+  
+## Architecture from Kubernetes perspective
+
+![image](https://github.com/user-attachments/assets/75135739-a0eb-4598-ab9d-71cc2f9fad9a)
+
+
+
 ## Notes
 
 The voting application only accepts one vote per client browser. It does not register additional votes if a vote has already been submitted from a client.
 
-This isn't an example of a properly architected perfectly designed distributed app... it's just a simple
+This isn't an example of a properly architected, perfectly designed distributed app... it's just a simple
 example of the various types of pieces and languages you might see (queues, persistent data, etc), and how to
 deal with them in Docker at a basic level.

--- a/k8s-specifications/networkpolicy.yaml
+++ b/k8s-specifications/networkpolicy.yaml
@@ -1,0 +1,12 @@
+kind: NetworkPolicy
+metadata:
+  name: access-redis
+spec:
+  podSelector:
+    matchLabels:
+      app: redis
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: "frontend"

--- a/k8s-specifications/result-service.yaml
+++ b/k8s-specifications/result-service.yaml
@@ -12,4 +12,4 @@ spec:
     targetPort: 80
     nodePort: 31001
   selector:
-    app: result
+    app: results

--- a/k8s-specifications/vote-service.yaml
+++ b/k8s-specifications/vote-service.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - name: "vote-service"
     port: 5000
-    targetPort: 80
+    targetPort: 8080
     nodePort: 31000
   selector:
     app: vote

--- a/k8s-specifications/worker-deployment.yaml
+++ b/k8s-specifications/worker-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app: worker
   name: worker
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app: worker


### PR DESCRIPTION
**Issue:** The worker deployment encountered internal server errors with only 1 replica. 

The frontend voting application crashes when we click multiple times on the vote button. Scaling the worker deployment to 3 replicas will distribute the load more evenly and significantly improve the web application's performance and stability. I updated replicas from 1 to 3 in worker deployment.yaml to fix the issue.