### PR TITLE
Added k8s helm charts 

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ To remove them, run:
 ```shell
 kubectl delete -f k8s-specifications/
 ```
+#### Deploying the Voting App Using Helm on Kubernetes
+
+The k8s-helm folder contains all the Helm charts for the Voting App's services.
+
+Run the following command to deploy the Voting App using the Helm charts:
+```shell
+helm install vote-helm k8s-helm/ -n <namespace>
+```
+To remove the deployment, run:
+
+```shell
+helm uninstall vote-helm -n <namespace>
+```
 
 ## Architecture
 

--- a/k8s-helm/.helmignore
+++ b/k8s-helm/.helmignore
@@ -1,0 +1,26 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# votingapp-vote.yml
+# votingapp-worker.yml
+# votingapp-result.yml

--- a/k8s-helm/Chart.yaml
+++ b/k8s-helm/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: k8s-helm
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/k8s-helm/templates/_helpers.tpl
+++ b/k8s-helm/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "k8s-helm.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "k8s-helm.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "k8s-helm.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "k8s-helm.labels" -}}
+helm.sh/chart: {{ include "k8s-helm.chart" . }}
+{{ include "k8s-helm.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "k8s-helm.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "k8s-helm.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "k8s-helm.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "k8s-helm.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/k8s-helm/templates/db.yml
+++ b/k8s-helm/templates/db.yml
@@ -1,0 +1,56 @@
+---
+#################################################
+################## Deployments ##################
+#################################################
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: db
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: {{ .Values.replicaCount}}
+  selector:
+    matchLabels:
+      app: db
+  template:
+    metadata:
+      labels:
+        app: db
+    spec:
+      containers:
+        - name: db
+          image: "{{ .Values.db.repository }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.localPort.db }}
+              protocol: TCP
+          env:
+            - name: POSTGRES_USER
+              value: {{ .Values.db.postgresUser }}
+            - name: POSTGRES_PASSWORD
+              value: {{ .Values.db.postgresPassword }}
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.localPort.db }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: db
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: db
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.ExportPort.db }}
+      targetPort: {{ .Values.localPort.db }}
+  selector:
+    app: db

--- a/k8s-helm/templates/redis.yml
+++ b/k8s-helm/templates/redis.yml
@@ -1,0 +1,53 @@
+---
+#################################################
+################## Deployments ##################
+#################################################
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: {{ .Values.replicaCount}}
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: "{{ .Values.image.repositoryRedis }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.localPort.redis }}
+              protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.localPort.redis }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+
+
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: redis
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.ExportPort.redis }}
+      targetPort: {{ .Values.localPort.redis }}
+  selector:
+    app: redis

--- a/k8s-helm/templates/votingapp-result.yml
+++ b/k8s-helm/templates/votingapp-result.yml
@@ -1,0 +1,53 @@
+---
+#################################################
+################## Deployments ##################
+#################################################
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: result
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: {{ .Values.replicaCount}}
+  selector:
+    matchLabels:
+      app: result
+  template:
+    metadata:
+      labels:
+        app: result
+    spec:
+      containers:
+        - name: result
+          image: "{{ .Values.image.repositoryResult }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.localPort.result }}
+              protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.localPort.result }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+
+
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: result
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: result
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.ExportPort.result }}
+      targetPort: {{ .Values.localPort.result }}
+  selector:
+    app: result

--- a/k8s-helm/templates/votingapp-vote.yml
+++ b/k8s-helm/templates/votingapp-vote.yml
@@ -1,0 +1,53 @@
+---
+#################################################
+################## Deployments ##################
+#################################################
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vote
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: {{ .Values.replicaCount}}
+  selector:
+    matchLabels:
+      app: vote
+  template:
+    metadata:
+      labels:
+        app: vote
+    spec:
+      containers:
+        - name: vote
+          image: "{{ .Values.image.repositoryVote }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.localPort.vote }}
+              protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.localPort.vote }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+
+
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vote
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: vote
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.ExportPort.vote }}
+      targetPort: {{ .Values.localPort.vote }}
+  selector:
+    app: vote

--- a/k8s-helm/templates/votingapp-worker.yml
+++ b/k8s-helm/templates/votingapp-worker.yml
@@ -1,0 +1,29 @@
+---
+#################################################
+################## Deployments ##################
+#################################################
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: {{ .Values.replicaCount}}
+  selector:
+    matchLabels:
+      app: worker
+  template:
+    metadata:
+      labels:
+        app: worker
+    spec:
+      containers:
+        - name: worker
+          image: "{{ .Values.image.repositoryWorker }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.localPort.worker }}
+              protocol: TCP
+
+

--- a/k8s-helm/values.yaml
+++ b/k8s-helm/values.yaml
@@ -1,0 +1,132 @@
+# Default values for k8s-helm.
+
+replicaCount: 1
+
+image:
+  repositoryVote: dockersamples/examplevotingapp_vote
+  repositoryResult: dockersamples/examplevotingapp_result
+  repositoryWorker: dockersamples/examplevotingapp_worker
+  repositoryRedis: redis:alpine
+
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: latest
+
+localPort:
+  vote: 80
+  result: 80
+  worker: 80
+  redis: 6379
+  db: 5432
+
+ExportPort:
+  vote: 5000
+  result: 5001
+  worker: 5002
+  redis: 6379
+  db: 5432
+
+db:
+  postgresUser: postgres
+  postgresPassword: postgres
+  repository: postgres:15-alpine
+
+imagePullSecrets: 
+  name: acr-cred 
+nameOverride: ""
+fullnameOverride: ""
+
+
+
+# ------------------------------------------------------------------------------
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
This pull request introduces Helm charts for the Voting App, designed to streamline the deployment and management of the app on Kubernetes clusters. The Helm charts are located in the k8s-helm directory.

Key Updates:

- Helm Charts Added: All required Helm charts for deploying the Voting App's services are included.

- Deployment Instructions: Updated README with commands for deploying and removing the app using Helm.

1. Deploy: helm install vote-helm ./k8s-helm/ -n <namespace>
2. Remove: helm uninstall vote-helm -n <namespace>

Benefits:

- Simplifies the deployment process with a single command.
- Facilitates easier management and scaling of services.
- Provides straightforward commands for cleanup.

Testing:

-Tested Helm charts locally to ensure correct deployment and functionality.
- Followed best practices for Helm chart structure and configuration.

Please review the changes and provide feedback. Your approval will help integrate these Helm charts into the public repository, enhancing the deployment process for the Voting App.