### PR TITLE
[Security] Harden IaC based on Sysdig CLI Scanner results

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,0 +1,1 @@
+404: Not Found

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -19,7 +19,7 @@ jobs:
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: Run Sysdig CLI Scanner (with CLI flags)
+      - name: Run Sysdig CLI Scanner (Dockerized)
         env:
           SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
         run: |
@@ -27,20 +27,20 @@ jobs:
             -v /var/run/docker.sock:/var/run/docker.sock \
             quay.io/sysdig/sysdig-cli-scanner:latest \
               --apiurl https://app.au1.sysdig.com \
-              --client-token $SECURE_API_TOKEN \
+              --token $SECURE_API_TOKEN \
               docker://voting-app
 
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             quay.io/sysdig/sysdig-cli-scanner:latest \
               --apiurl https://app.au1.sysdig.com \
-              --client-token $SECURE_API_TOKEN \
+              --token $SECURE_API_TOKEN \
               docker://worker
 
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             quay.io/sysdig/sysdig-cli-scanner:latest \
               --apiurl https://app.au1.sysdig.com \
-              --client-token $SECURE_API_TOKEN \
+              --token $SECURE_API_TOKEN \
               docker://result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -28,7 +28,7 @@ jobs:
           SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
           SYS_DIG_SECURE_URL: https://app.au1.sysdig.com
         run: |
-          ./scanner --apiurl $SYS_DIG_SECURE_URL --token $SECURE_API_TOKEN docker://voting-app
-          ./scanner --apiurl $SYS_DIG_SECURE_URL --token $SECURE_API_TOKEN docker://worker
-          ./scanner --apiurl $SYS_DIG_SECURE_URL --token $SECURE_API_TOKEN docker://result
+          ./scanner --apiurl $SYS_DIG_SECURE_URL --auth-token $SECURE_API_TOKEN docker://voting-app
+          ./scanner --apiurl $SYS_DIG_SECURE_URL --auth-token $SECURE_API_TOKEN docker://worker
+          ./scanner --apiurl $SYS_DIG_SECURE_URL --auth-token $SECURE_API_TOKEN docker://result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -20,11 +20,12 @@ jobs:
           docker build -t result ./result
 
       - name: Download Sysdig CLI Scanner
-        run: |
-          LATEST_VERSION=$(curl -sSL https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt)
-          curl -sSL "https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/${LATEST_VERSION}/linux/amd64/sysdig-cli-scanner" -o sysdig-cli-scanner
-          chmod +x sysdig-cli-scanner
-          ./sysdig-cli-scanner version
+        run: | 
+　　　　　version=$(curl -sSL https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt)
+    　　　echo "Latest version is $version"
+    　　　curl -sSL "https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/${version}/linux/amd64/sysdig-cli-scanner" -o sysdig-cli-scanner
+    　　　chmod +x sysdig-cli-scanner
+    　　　./sysdig-cli-scanner --version
       - name: Run Sysdig Image Scan
         env:
           SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,16 +1,15 @@
 name: Sysdig Image Scan
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
-  workflow_dispatch:
 
 jobs:
   image-scan:
     runs-on: ubuntu-latest
 
-    # 🧪 環境変数の注入（Secretsから取得）
     env:
       SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
       SYS_DIG_SECURE_URL: https://app.au1.sysdig.com
@@ -19,39 +18,51 @@ jobs:
       - name: 🛎️ Checkout code
         uses: actions/checkout@v3
 
-      - name: 🏗️ Build Docker images
+      - name: 🧱 Build Docker images
         run: |
           docker build -t voting-app ./vote
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: 🔍 Run Sysdig Scan (voting-app)
+      - name: 🔍 Scan voting-app with Sysdig
         run: |
           docker run --rm \
+            --platform linux/amd64 \
+            --user 0 \
+            -v "${{ github.workspace }}/scan-logs:/home/nonroot/scan-logs" \
             -v /var/run/docker.sock:/var/run/docker.sock \
+            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-            scan \
-            --apiurl $SYS_DIG_SECURE_URL \
-            --token $SECURE_API_TOKEN \
-            docker://voting-app
+              --apiurl $SYS_DIG_SECURE_URL \
+              --loglevel debug \
+              --skiptlsverify \
+              docker://voting-app
 
-      - name: 🔍 Run Sysdig Scan (worker)
+      - name: 🔍 Scan worker with Sysdig
         run: |
           docker run --rm \
+            --platform linux/amd64 \
+            --user 0 \
+            -v "${{ github.workspace }}/scan-logs:/home/nonroot/scan-logs" \
             -v /var/run/docker.sock:/var/run/docker.sock \
+            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-            scan \
-            --apiurl $SYS_DIG_SECURE_URL \
-            --token $SECURE_API_TOKEN \
-            docker://worker
+              --apiurl $SYS_DIG_SECURE_URL \
+              --loglevel debug \
+              --skiptlsverify \
+              docker://worker
 
-      - name: 🔍 Run Sysdig Scan (result)
+      - name: 🔍 Scan result with Sysdig
         run: |
           docker run --rm \
+            --platform linux/amd64 \
+            --user 0 \
+            -v "${{ github.workspace }}/scan-logs:/home/nonroot/scan-logs" \
             -v /var/run/docker.sock:/var/run/docker.sock \
+            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-            scan \
-            --apiurl $SYS_DIG_SECURE_URL \
-            --token $SECURE_API_TOKEN \
-            docker://result
+              --apiurl $SYS_DIG_SECURE_URL \
+              --loglevel debug \
+              --skiptlsverify \
+              docker://result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   image-scan:
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -30,7 +31,7 @@ jobs:
             quay.io/sysdig/sysdig-cli-scanner:latest \
             scan docker://voting-app \
             --apiurl $SYS_DIG_SECURE_URL \
-            --client-token $SECURE_API_TOKEN
+            --token $SECURE_API_TOKEN
 
       - name: Run Sysdig Scan on worker
         run: |
@@ -39,7 +40,7 @@ jobs:
             quay.io/sysdig/sysdig-cli-scanner:latest \
             scan docker://worker \
             --apiurl $SYS_DIG_SECURE_URL \
-            --client-token $SECURE_API_TOKEN
+            --token $SECURE_API_TOKEN
 
       - name: Run Sysdig Scan on result
         run: |
@@ -48,5 +49,5 @@ jobs:
             quay.io/sysdig/sysdig-cli-scanner:latest \
             scan docker://result \
             --apiurl $SYS_DIG_SECURE_URL \
-            --client-token $SECURE_API_TOKEN
+            --token $SECURE_API_TOKEN
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
+      - name: Checkout source
         uses: actions/checkout@v3
 
       - name: Build Docker images
@@ -21,19 +21,18 @@ jobs:
 
       - name: Download Sysdig CLI Scanner
         run: |
-          echo "Fetching latest scanner version..."
           VERSION=$(curl -sSL https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt)
           echo "Latest version: $VERSION"
           curl -sSL "https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/${VERSION}/linux/amd64/sysdig-cli-scanner" -o sysdig-cli-scanner
           chmod +x sysdig-cli-scanner
           ./sysdig-cli-scanner --version
 
-      - name: Run Sysdig Scan
+      - name: Run Sysdig CLI Scanner
         env:
           SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
           SYS_DIG_SECURE_URL: https://app.au1.sysdig.com
         run: |
-          ./sysdig-cli-scanner --apiurl $SYS_DIG_SECURE_URL --auth-token $SECURE_API_TOKEN docker://voting-app
-          ./sysdig-cli-scanner --apiurl $SYS_DIG_SECURE_URL --auth-token $SECURE_API_TOKEN docker://worker
-          ./sysdig-cli-scanner --apiurl $SYS_DIG_SECURE_URL --auth-token $SECURE_API_TOKEN docker://result
+          ./sysdig-cli-scanner --apiurl $SYS_DIG_SECURE_URL --token $SECURE_API_TOKEN docker://voting-app
+          ./sysdig-cli-scanner --apiurl $SYS_DIG_SECURE_URL --token $SECURE_API_TOKEN docker://worker
+          ./sysdig-cli-scanner --apiurl $SYS_DIG_SECURE_URL --token $SECURE_API_TOKEN docker://result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -11,48 +11,48 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: 🛎️ Checkout code
+      - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: 🧱 Build Docker images
+      - name: Build Docker images
         run: |
           docker build -t voting-app ./vote
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: 🔍 Scan with Sysdig (voting-app)
+      - name: Run Sysdig Scan (voting-app)
         run: |
           docker run --rm \
             --platform linux/amd64 \
             --user 0 \
+            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
               --apiurl https://app.au1.sysdig.com \
               --loglevel info \
               --skiptlsverify \
               docker://voting-app
 
-      - name: 🔍 Scan with Sysdig (worker)
+      - name: Run Sysdig Scan (worker)
         run: |
           docker run --rm \
             --platform linux/amd64 \
             --user 0 \
+            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
               --apiurl https://app.au1.sysdig.com \
               --loglevel info \
               --skiptlsverify \
               docker://worker
 
-      - name: 🔍 Scan with Sysdig (result)
+      - name: Run Sysdig Scan (result)
         run: |
           docker run --rm \
             --platform linux/amd64 \
             --user 0 \
+            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
               --apiurl https://app.au1.sysdig.com \
               --loglevel info \

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -20,45 +20,39 @@ jobs:
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: 🛡️ Scan voting-app with Sysdig
-        env:
-          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
+      - name: 🔍 Scan with Sysdig (voting-app)
         run: |
           docker run --rm \
             --platform linux/amd64 \
             --user 0 \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN=$SECURE_API_TOKEN \
+            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
               --apiurl https://app.au1.sysdig.com \
               --loglevel info \
               --skiptlsverify \
               docker://voting-app
 
-      - name: 🛡️ Scan worker with Sysdig
-        env:
-          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
+      - name: 🔍 Scan with Sysdig (worker)
         run: |
           docker run --rm \
             --platform linux/amd64 \
             --user 0 \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN=$SECURE_API_TOKEN \
+            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
               --apiurl https://app.au1.sysdig.com \
               --loglevel info \
               --skiptlsverify \
               docker://worker
 
-      - name: 🛡️ Scan result with Sysdig
-        env:
-          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
+      - name: 🔍 Scan with Sysdig (result)
         run: |
           docker run --rm \
             --platform linux/amd64 \
             --user 0 \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN=$SECURE_API_TOKEN \
+            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
               --apiurl https://app.au1.sysdig.com \
               --loglevel info \

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -23,9 +23,11 @@ jobs:
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: Set SECURE_API_TOKEN env and debug
+      - 
+        name: Debug: Check if SECURE_API_TOKEN is available
+        env:
+          SECURE_API_TOKEN: "${{ secrets.SECURE_API_TOKEN }}"
         run: |
-          export SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}"
           echo "🔍 Token Length: ${#SECURE_API_TOKEN}"
           echo "🔍 Token Head: ${SECURE_API_TOKEN:0:5}"
           if [ -z "$SECURE_API_TOKEN" ]; then
@@ -37,15 +39,5 @@ jobs:
 
       - name: Run Sysdig Scan (voting-app)
         run: |
-          docker run --rm \
-            --platform linux/amd64 \
-            --user 0 \
-            -v "$(pwd)/scan-logs:/home/nonroot/scan-logs" \
-            -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
-            quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              --apiurl "$SYS_DIG_SECURE_URL" \
-              --loglevel debug \
-              --skiptlsverify \
-              docker://voting-app
+          docker run --rm             --platform linux/amd64             --user 0             -v "$(pwd)/scan-logs:/home/nonroot/scan-logs"             -v /var/run/docker.sock:/var/run/docker.sock             -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}"             quay.io/sysdig/sysdig-cli-scanner:1.22.4               --apiurl "$SYS_DIG_SECURE_URL"               --loglevel debug               --skiptlsverify               docker://voting-app
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -2,19 +2,19 @@ name: Sysdig Image Scan
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
   workflow_dispatch:
 
 env:
-  SYSDIG_SECURE_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
   SYSDIG_SECURE_URL: https://app.au1.sysdig.com
 
 jobs:
-  scan:
+  image-scan:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout source
+      - name: Checkout code
         uses: actions/checkout@v3
 
       - name: Build Docker images
@@ -23,29 +23,27 @@ jobs:
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: Run Sysdig Scan via Docker image (scan subcommand)
+      - name: Run Sysdig Scan on voting-app
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SYSDIG_SECURE_TOKEN=$SYSDIG_SECURE_TOKEN \
+            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              scan \
-              --apiurl $SYSDIG_SECURE_URL \
-              docker://voting-app
+              scan --apiurl $SYSDIG_SECURE_URL docker://voting-app
 
+      - name: Run Sysdig Scan on worker
+        run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SYSDIG_SECURE_TOKEN=$SYSDIG_SECURE_TOKEN \
+            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              scan \
-              --apiurl $SYSDIG_SECURE_URL \
-              docker://worker
+              scan --apiurl $SYSDIG_SECURE_URL docker://worker
 
+      - name: Run Sysdig Scan on result
+        run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SYSDIG_SECURE_TOKEN=$SYSDIG_SECURE_TOKEN \
+            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              scan \
-              --apiurl $SYSDIG_SECURE_URL \
-              docker://result
+              scan --apiurl $SYSDIG_SECURE_URL docker://result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,9 +1,8 @@
-name: Sysdig Image Scan
+name: Sysdig Docker Image Scan
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
   workflow_dispatch:
 
 env:
@@ -15,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v3
 
       - name: Build Docker images
@@ -24,30 +23,30 @@ jobs:
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: Run Sysdig Scan on voting-app
+      - name: Scan voting-app
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             quay.io/sysdig/sysdig-cli-scanner:latest \
             scan docker://voting-app \
-            --apiurl $SYS_DIG_SECURE_URL \
-            --token $SECURE_API_TOKEN
+              --apiurl "$SYS_DIG_SECURE_URL" \
+              --token "$SECURE_API_TOKEN"
 
-      - name: Run Sysdig Scan on worker
+      - name: Scan worker
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             quay.io/sysdig/sysdig-cli-scanner:latest \
             scan docker://worker \
-            --apiurl $SYS_DIG_SECURE_URL \
-            --token $SECURE_API_TOKEN
+              --apiurl "$SYS_DIG_SECURE_URL" \
+              --token "$SECURE_API_TOKEN"
 
-      - name: Run Sysdig Scan on result
+      - name: Scan result
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             quay.io/sysdig/sysdig-cli-scanner:latest \
             scan docker://result \
-            --apiurl $SYS_DIG_SECURE_URL \
-            --token $SECURE_API_TOKEN
+              --apiurl "$SYS_DIG_SECURE_URL" \
+              --token "$SECURE_API_TOKEN"
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -2,8 +2,7 @@ name: Sysdig Image Scan
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
   workflow_dispatch:
 
 jobs:
@@ -11,8 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
       - name: Build Docker images
         run: |
@@ -22,14 +20,15 @@ jobs:
 
       - name: Download Sysdig CLI Scanner
         run: |
-          curl -sSL https://download.sysdig.com/scanning/sysdig-cli-scanner/latest/sysdig-cli-scanner-linux-amd64 -o scanner
+          curl -sSL "https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/$(curl -L -s https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt)/linux/amd64/sysdig-cli-scanner" -o scanner
           chmod +x scanner
 
-      - name: Run Sysdig Scan on voting-app
-        run: ./scanner --token ${{ secrets.SYSDIG_SECURE_TOKEN }} --image voting-app
+      - name: Run Sysdig Scan
+        env:
+          SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
+          SYS_DIG_SECURE_URL: https://app.au1.sysdig.com
+        run: |
+          ./scanner --apiurl $SYS_DIG_SECURE_URL --token $SECURE_API_TOKEN docker://voting-app
+          ./scanner --apiurl $SYS_DIG_SECURE_URL --token $SECURE_API_TOKEN docker://worker
+          ./scanner --apiurl $SYS_DIG_SECURE_URL --token $SECURE_API_TOKEN docker://result
 
-      - name: Run Sysdig Scan on worker
-        run: ./scanner --token ${{ secrets.SYSDIG_SECURE_TOKEN }} --image worker
-
-      - name: Run Sysdig Scan on result
-        run: ./scanner --token ${{ secrets.SYSDIG_SECURE_TOKEN }} --image result

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -10,58 +10,68 @@ jobs:
   image-scan:
     runs-on: ubuntu-latest
 
+    env:
+      SYS_DIG_SECURE_URL: https://app.au1.sysdig.com
+
     steps:
       - name: 🛎️ Checkout code
         uses: actions/checkout@v3
 
-      - name: 🏗️ Build Docker images
+      - name: 🐳 Build Docker images
         run: |
           docker build -t voting-app ./vote
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: 🔍 Run Sysdig Scan (voting-app)
+      - name: 🔍 DEBUG: Check if SECURE_API_TOKEN is available
+        run: |
+          echo "🔍 Token Length: ${#SECURE_API_TOKEN}"
+          echo "🔍 Token Head: ${SECURE_API_TOKEN::5}"
+          if [ -z "$SECURE_API_TOKEN" ]; then
+            echo "❌ SECURE_API_TOKEN is NOT set!"
+            exit 1
+          else
+            echo "✅ SECURE_API_TOKEN is available."
+          fi
         env:
           SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
+
+      - name: 🔍 Run Sysdig Scan (voting-app)
         run: |
           docker run --rm \
             --platform linux/amd64 \
             --user 0 \
-            -e SECURE_API_TOKEN=$SECURE_API_TOKEN \
             -v /var/run/docker.sock:/var/run/docker.sock \
+            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              scan \
-              --apiurl https://app.au1.sysdig.com \
+              --apiurl $SYS_DIG_SECURE_URL \
               --skiptlsverify \
+              --loglevel debug \
               docker://voting-app
 
       - name: 🔍 Run Sysdig Scan (worker)
-        env:
-          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
         run: |
           docker run --rm \
             --platform linux/amd64 \
             --user 0 \
-            -e SECURE_API_TOKEN=$SECURE_API_TOKEN \
             -v /var/run/docker.sock:/var/run/docker.sock \
+            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              scan \
-              --apiurl https://app.au1.sysdig.com \
+              --apiurl $SYS_DIG_SECURE_URL \
               --skiptlsverify \
+              --loglevel debug \
               docker://worker
 
       - name: 🔍 Run Sysdig Scan (result)
-        env:
-          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
         run: |
           docker run --rm \
             --platform linux/amd64 \
             --user 0 \
-            -e SECURE_API_TOKEN=$SECURE_API_TOKEN \
             -v /var/run/docker.sock:/var/run/docker.sock \
+            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              scan \
-              --apiurl https://app.au1.sysdig.com \
+              --apiurl $SYS_DIG_SECURE_URL \
               --skiptlsverify \
+              --loglevel debug \
               docker://result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -23,9 +23,9 @@ jobs:
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: Debug
+      - name: Debug: Check if SECURE_API_TOKEN is available
         env:
-          SECURE_API_TOKEN: "${{ secrets.SECURE_API_TOKEN }}"
+          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
         run: |
           echo "🔍 Token Length: ${#SECURE_API_TOKEN}"
           echo "🔍 Token Head: ${SECURE_API_TOKEN:0:5}"
@@ -34,6 +34,7 @@ jobs:
             exit 1
           else
             echo "✅ SECURE_API_TOKEN is available."
+          fi
 
       - name: Run Sysdig Scan (voting-app)
         run: |

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Download Sysdig CLI Scanner
         run: |
-          curl -sLo scanner https://download.sysdig.com/scanning/sysdig-cli-scanner/latest/sysdig-cli-scanner-linux-amd64
+          curl -sSL https://download.sysdig.com/scanning/sysdig-cli-scanner/latest/sysdig-cli-scanner-linux-amd64 -o scanner
           chmod +x scanner
 
       - name: Run Sysdig Scan on voting-app

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,4 +1,4 @@
-name: Sysdig Docker Image Scan
+name: Sysdig Image Scan
 
 on:
   push:
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
 
 env:
-  SYS_DIG_SECURE_URL: https://app.au1.sysdig.com
-  SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
+  SYSDIG_SECURE_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
+  SYSDIG_SECURE_URL: https://app.au1.sysdig.com
 
 jobs:
   scan:
@@ -23,26 +23,29 @@ jobs:
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: Run Sysdig CLI Scanner via Docker
+      - name: Run Sysdig Scan via Docker image (scan subcommand)
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
+            -e SYSDIG_SECURE_TOKEN=$SYSDIG_SECURE_TOKEN \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              --apiurl $SYS_DIG_SECURE_URL \
-              --token $SECURE_API_TOKEN \
+              scan \
+              --apiurl $SYSDIG_SECURE_URL \
               docker://voting-app
 
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
+            -e SYSDIG_SECURE_TOKEN=$SYSDIG_SECURE_TOKEN \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              --apiurl $SYS_DIG_SECURE_URL \
-              --token $SECURE_API_TOKEN \
+              scan \
+              --apiurl $SYSDIG_SECURE_URL \
               docker://worker
 
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
+            -e SYSDIG_SECURE_TOKEN=$SYSDIG_SECURE_TOKEN \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              --apiurl $SYS_DIG_SECURE_URL \
-              --token $SECURE_API_TOKEN \
+              scan \
+              --apiurl $SYSDIG_SECURE_URL \
               docker://result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -28,7 +28,7 @@ jobs:
           SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
         run: |
           echo "🔍 Token Length: ${#SECURE_API_TOKEN}"
-          echo "🔍 Token Head: ${SECURE_API_TOKEN::5}"
+          echo "🔍 Token Head: ${SECURE_API_TOKEN:0:5}"
           if [ -z "$SECURE_API_TOKEN" ]; then
             echo "❌ SECURE_API_TOKEN is NOT set!"
             exit 1

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -6,15 +6,15 @@ on:
   workflow_dispatch:
 
 env:
-  SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
   SYS_DIG_SECURE_URL: https://app.au1.sysdig.com
+  SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
 
 jobs:
-  image-scan:
+  scan:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Checkout source
         uses: actions/checkout@v3
 
       - name: Build Docker images
@@ -23,30 +23,26 @@ jobs:
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: Scan voting-app
+      - name: Run Sysdig CLI Scanner via Docker
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            quay.io/sysdig/sysdig-cli-scanner:latest \
-            scan docker://voting-app \
-              --apiurl "$SYS_DIG_SECURE_URL" \
-              --token "$SECURE_API_TOKEN"
+            quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
+              --apiurl $SYS_DIG_SECURE_URL \
+              --token $SECURE_API_TOKEN \
+              docker://voting-app
 
-      - name: Scan worker
-        run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            quay.io/sysdig/sysdig-cli-scanner:latest \
-            scan docker://worker \
-              --apiurl "$SYS_DIG_SECURE_URL" \
-              --token "$SECURE_API_TOKEN"
+            quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
+              --apiurl $SYS_DIG_SECURE_URL \
+              --token $SECURE_API_TOKEN \
+              docker://worker
 
-      - name: Scan result
-        run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            quay.io/sysdig/sysdig-cli-scanner:latest \
-            scan docker://result \
-              --apiurl "$SYS_DIG_SECURE_URL" \
-              --token "$SECURE_API_TOKEN"
+            quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
+              --apiurl $SYS_DIG_SECURE_URL \
+              --token $SECURE_API_TOKEN \
+              docker://result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Checkout code
         uses: actions/checkout@v3
 
       - name: Build Docker images
@@ -19,29 +19,28 @@ jobs:
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: Run Sysdig CLI Scanner (Dockerized)
+      - name: Run Sysdig CLI Scanner (with CLI flags)
         env:
-          SYSDIG_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
-          SYSDIG_API_URL: https://app.au1.sysdig.com
+          SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SYSDIG_API_TOKEN \
-            -e SYSDIG_API_URL \
-            quay.io/sysdig/sysdig-cli-scanner \
+            quay.io/sysdig/sysdig-cli-scanner:latest \
+              --apiurl https://app.au1.sysdig.com \
+              --client-token $SECURE_API_TOKEN \
               docker://voting-app
 
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SYSDIG_API_TOKEN \
-            -e SYSDIG_API_URL \
-            quay.io/sysdig/sysdig-cli-scanner \
+            quay.io/sysdig/sysdig-cli-scanner:latest \
+              --apiurl https://app.au1.sysdig.com \
+              --client-token $SECURE_API_TOKEN \
               docker://worker
 
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SYSDIG_API_TOKEN \
-            -e SYSDIG_API_URL \
-            quay.io/sysdig/sysdig-cli-scanner \
+            quay.io/sysdig/sysdig-cli-scanner:latest \
+              --apiurl https://app.au1.sysdig.com \
+              --client-token $SECURE_API_TOKEN \
               docker://result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -2,13 +2,17 @@ name: Sysdig Image Scan
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
   workflow_dispatch:
 
-jobs:
-  scan:
-    runs-on: ubuntu-latest
+env:
+  SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
+  SYS_DIG_SECURE_URL: https://app.au1.sysdig.com
 
+jobs:
+  image-scan:
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -19,28 +23,30 @@ jobs:
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: Run Sysdig CLI Scanner (Dockerized)
-        env:
-          SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
+      - name: Run Sysdig Scan on voting-app
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             quay.io/sysdig/sysdig-cli-scanner:latest \
-              --apiurl https://app.au1.sysdig.com \
-              --token $SECURE_API_TOKEN \
-              docker://voting-app
+            scan docker://voting-app \
+            --apiurl $SYS_DIG_SECURE_URL \
+            --client-token $SECURE_API_TOKEN
 
+      - name: Run Sysdig Scan on worker
+        run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             quay.io/sysdig/sysdig-cli-scanner:latest \
-              --apiurl https://app.au1.sysdig.com \
-              --token $SECURE_API_TOKEN \
-              docker://worker
+            scan docker://worker \
+            --apiurl $SYS_DIG_SECURE_URL \
+            --client-token $SECURE_API_TOKEN
 
+      - name: Run Sysdig Scan on result
+        run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             quay.io/sysdig/sysdig-cli-scanner:latest \
-              --apiurl https://app.au1.sysdig.com \
-              --token $SECURE_API_TOKEN \
-              docker://result
+            scan docker://result \
+            --apiurl $SYS_DIG_SECURE_URL \
+            --client-token $SECURE_API_TOKEN
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -14,29 +14,29 @@ jobs:
       SYS_DIG_SECURE_URL: https://app.au1.sysdig.com
 
     steps:
-      - name: 🛎️ Checkout code
+      - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: 🏗️ Build Docker images
+      - name: Build Docker images
         run: |
           docker build -t voting-app ./vote
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: 🔍 DEBUG: Check if SECURE_API_TOKEN is available
-        env:
-          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
+      - name: Debug: Check if SECURE_API_TOKEN is available
         run: |
-          echo "🔍 Token Length: ${#SECURE_API_TOKEN}"
-          echo "🔍 Token Head: ${SECURE_API_TOKEN:0:5}"
+          echo "Token Length: ${#SECURE_API_TOKEN}"
+          echo "Token Head: ${SECURE_API_TOKEN:0:5}"
           if [ -z "$SECURE_API_TOKEN" ]; then
-            echo "❌ SECURE_API_TOKEN is NOT set!"
+            echo "SECURE_API_TOKEN is NOT set!"
             exit 1
           else
-            echo "✅ SECURE_API_TOKEN is available."
+            echo "SECURE_API_TOKEN is available."
           fi
+        env:
+          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
 
-      - name: 🔍 Run Sysdig Scan (voting-app)
+      - name: Run Sysdig Scan (voting-app)
         run: |
           docker run --rm \
             --platform linux/amd64 \

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -22,7 +22,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Log in to DockerHub (optional)
-        if: secrets.DOCKERHUB_USERNAME && secrets.DOCKERHUB_TOKEN
+        if: ${{ secrets.DOCKERHUB_USERNAME && secrets.DOCKERHUB_TOKEN }}
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -38,14 +38,5 @@ jobs:
         env:
           SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
         run: |
-          docker run --rm \
-            --platform linux/amd64 \
-            --user 0 \
-            -v "$(pwd)/scan-logs:/home/nonroot/scan-logs" \
-            -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
-            quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              --apiurl "$SYS_DIG_SECURE_URL" \
-              --loglevel info \
-              --skiptlsverify \
-              docker://voting-app
+          docker run --rm             --platform linux/amd64             --user 0             -v "$(pwd)/scan-logs:/home/nonroot/scan-logs"             -v /var/run/docker.sock:/var/run/docker.sock             -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}"             quay.io/sysdig/sysdig-cli-scanner:1.22.4               --apiurl "$SYS_DIG_SECURE_URL"               --loglevel info               --skiptlsverify               docker://voting-app
+

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -25,15 +25,15 @@ jobs:
 
       - name: Debug
         env:
-          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
+          SYSDIG_SECURE_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
         run: |
-          echo "🔍 Token Length: ${#SECURE_API_TOKEN}"
-          echo "🔍 Token Head: ${SECURE_API_TOKEN:0:5}"
-          if [ -z "$SECURE_API_TOKEN" ]; then
-            echo "❌ SECURE_API_TOKEN is NOT set!"
+          echo "🔍 Token Length: ${#SYSDIG_SECURE_TOKEN}"
+          echo "🔍 Token Head: ${SYSDIG_SECURE_TOKEN:0:5}"
+          if [ -z "$SYSDIG_SECURE_TOKEN" ]; then
+            echo "❌ SYSDIG_SECURE_TOKEN is NOT set!"
             exit 1
           else
-            echo "✅ SECURE_API_TOKEN is available."
+            echo "✅ SYSDIG_SECURE_TOKEN is available."
           fi
 
       - name: Run Sysdig Scan (voting-app)
@@ -43,7 +43,7 @@ jobs:
             --user 0 \
             -v "$(pwd)/scan-logs:/home/nonroot/scan-logs" \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
+            -e SYSDIG_SECURE_TOKEN="${{ secrets.SYSDIG_SECURE_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
               --apiurl "$SYS_DIG_SECURE_URL" \
               --loglevel debug \

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -10,7 +10,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout source
+        uses: actions/checkout@v3
 
       - name: Build Docker images
         run: |
@@ -20,10 +21,10 @@ jobs:
 
       - name: Download Sysdig CLI Scanner
         run: |
-          curl -sSL "https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/$(curl -L -s https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt)/linux/amd64/sysdig-cli-scanner" -o scanner
+          curl -sSL "https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/$(curl -sSL https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt)/linux/amd64/sysdig-cli-scanner" -o scanner
           chmod +x scanner
 
-      - name: Run Sysdig Scan
+      - name: Run Sysdig Image Scan
         env:
           SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
           SYS_DIG_SECURE_URL: https://app.au1.sysdig.com

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -21,9 +21,10 @@ jobs:
 
       - name: Download Sysdig CLI Scanner
         run: |
-          curl -sSL "https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/$(curl -sSL https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt)/linux/amd64/sysdig-cli-scanner" -o scanner
-          chmod +x scanner
-
+          LATEST_VERSION=$(curl -sSL https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt)
+          curl -sSL "https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/${LATEST_VERSION}/linux/amd64/sysdig-cli-scanner" -o sysdig-cli-scanner
+          chmod +x sysdig-cli-scanner
+          ./sysdig-cli-scanner version
       - name: Run Sysdig Image Scan
         env:
           SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -10,7 +10,7 @@ jobs:
   image-scan:
     runs-on: ubuntu-latest
 
-    # 🧪 環境変数の注入（ここが非常に重要）
+    # 🧪 環境変数の注入（Secretsから取得）
     env:
       SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
       SYS_DIG_SECURE_URL: https://app.au1.sysdig.com
@@ -30,28 +30,28 @@ jobs:
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              scan \
-              --apiurl $SYS_DIG_SECURE_URL \
-              --token $SECURE_API_TOKEN \
-              docker://voting-app
+            scan \
+            --apiurl $SYS_DIG_SECURE_URL \
+            --token $SECURE_API_TOKEN \
+            docker://voting-app
 
       - name: 🔍 Run Sysdig Scan (worker)
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              scan \
-              --apiurl $SYS_DIG_SECURE_URL \
-              --token $SECURE_API_TOKEN \
-              docker://worker
+            scan \
+            --apiurl $SYS_DIG_SECURE_URL \
+            --token $SECURE_API_TOKEN \
+            docker://worker
 
       - name: 🔍 Run Sysdig Scan (result)
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              scan \
-              --apiurl $SYS_DIG_SECURE_URL \
-              --token $SECURE_API_TOKEN \
-              docker://result
+            scan \
+            --apiurl $SYS_DIG_SECURE_URL \
+            --token $SECURE_API_TOKEN \
+            docker://result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Build Docker images
         run: |
-          docker build -t voting-app ./voting-app
+          docker build -t voting-app ./vote
           docker build -t worker ./worker
           docker build -t result ./result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -6,12 +6,12 @@ on:
       - main
   workflow_dispatch:
 
-env:
-  SYSDIG_SECURE_URL: https://app.au1.sysdig.com
-
 jobs:
   image-scan:
     runs-on: ubuntu-latest
+
+    env:
+      SYSDIG_SECURE_URL: https://app.au1.sysdig.com
 
     steps:
       - name: Checkout code
@@ -23,27 +23,27 @@ jobs:
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: Run Sysdig Scan on voting-app
+      - name: Scan voting-app image with Sysdig CLI
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              scan --apiurl $SYSDIG_SECURE_URL docker://voting-app
+            scan --apiurl "${SYSDIG_SECURE_URL}" docker://voting-app
 
-      - name: Run Sysdig Scan on worker
+      - name: Scan worker image with Sysdig CLI
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              scan --apiurl $SYSDIG_SECURE_URL docker://worker
+            scan --apiurl "${SYSDIG_SECURE_URL}" docker://worker
 
-      - name: Run Sysdig Scan on result
+      - name: Scan result image with Sysdig CLI
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              scan --apiurl $SYSDIG_SECURE_URL docker://result
+            scan --apiurl "${SYSDIG_SECURE_URL}" docker://result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -49,4 +49,3 @@ jobs:
               --loglevel info \
               --skiptlsverify \
               docker://voting-app
-

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -23,8 +23,7 @@ jobs:
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - 
-        name: Debug: Check if SECURE_API_TOKEN is available
+      - name: Debug
         env:
           SECURE_API_TOKEN: "${{ secrets.SECURE_API_TOKEN }}"
         run: |
@@ -35,9 +34,18 @@ jobs:
             exit 1
           else
             echo "✅ SECURE_API_TOKEN is available."
-          fi
 
       - name: Run Sysdig Scan (voting-app)
         run: |
-          docker run --rm             --platform linux/amd64             --user 0             -v "$(pwd)/scan-logs:/home/nonroot/scan-logs"             -v /var/run/docker.sock:/var/run/docker.sock             -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}"             quay.io/sysdig/sysdig-cli-scanner:1.22.4               --apiurl "$SYS_DIG_SECURE_URL"               --loglevel debug               --skiptlsverify               docker://voting-app
+          docker run --rm \
+            --platform linux/amd64 \
+            --user 0 \
+            -v "$(pwd)/scan-logs:/home/nonroot/scan-logs" \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
+            quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
+              --apiurl "$SYS_DIG_SECURE_URL" \
+              --loglevel debug \
+              --skiptlsverify \
+              docker://voting-app
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -25,15 +25,15 @@ jobs:
 
       - name: Debug
         env:
-          SYSDIG_SECURE_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
+          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
         run: |
-          echo "🔍 Token Length: ${#SYSDIG_SECURE_TOKEN}"
-          echo "🔍 Token Head: ${SYSDIG_SECURE_TOKEN:0:5}"
-          if [ -z "$SYSDIG_SECURE_TOKEN" ]; then
-            echo "❌ SYSDIG_SECURE_TOKEN is NOT set!"
+          echo "🔍 Token Length: ${#SECURE_API_TOKEN}"
+          echo "🔍 Token Head: ${SECURE_API_TOKEN:0:5}"
+          if [ -z "$SECURE_API_TOKEN" ]; then
+            echo "❌ SECURE_API_TOKEN is NOT set!"
             exit 1
           else
-            echo "✅ SYSDIG_SECURE_TOKEN is available."
+            echo "✅ SECURE_API_TOKEN is available."
           fi
 
       - name: Run Sysdig Scan (voting-app)
@@ -43,7 +43,7 @@ jobs:
             --user 0 \
             -v "$(pwd)/scan-logs:/home/nonroot/scan-logs" \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SYSDIG_SECURE_TOKEN="${{ secrets.SYSDIG_SECURE_TOKEN }}" \
+            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
               --apiurl "$SYS_DIG_SECURE_URL" \
               --loglevel debug \

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -24,6 +24,8 @@ jobs:
           docker build -t result ./result
 
       - name: 🔍 DEBUG: Check if SECURE_API_TOKEN is available
+        env:
+          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
         run: |
           echo "🔍 Token Length: ${#SECURE_API_TOKEN}"
           echo "🔍 Token Head: ${SECURE_API_TOKEN::5}"
@@ -33,8 +35,6 @@ jobs:
           else
             echo "✅ SECURE_API_TOKEN is available."
           fi
-        env:
-          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
 
       - name: 🔍 Run Sysdig Scan (voting-app)
         run: |

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -10,40 +10,48 @@ jobs:
   image-scan:
     runs-on: ubuntu-latest
 
+    # 🧪 環境変数の注入（ここが非常に重要）
     env:
-      SYSDIG_SECURE_URL: https://app.au1.sysdig.com
+      SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
+      SYS_DIG_SECURE_URL: https://app.au1.sysdig.com
 
     steps:
-      - name: Checkout code
+      - name: 🛎️ Checkout code
         uses: actions/checkout@v3
 
-      - name: Build Docker images
+      - name: 🏗️ Build Docker images
         run: |
           docker build -t voting-app ./vote
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: Scan voting-app image with Sysdig CLI
+      - name: 🔍 Run Sysdig Scan (voting-app)
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-            scan --apiurl "${SYSDIG_SECURE_URL}" docker://voting-app
+              scan \
+              --apiurl $SYS_DIG_SECURE_URL \
+              --token $SECURE_API_TOKEN \
+              docker://voting-app
 
-      - name: Scan worker image with Sysdig CLI
+      - name: 🔍 Run Sysdig Scan (worker)
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-            scan --apiurl "${SYSDIG_SECURE_URL}" docker://worker
+              scan \
+              --apiurl $SYS_DIG_SECURE_URL \
+              --token $SECURE_API_TOKEN \
+              docker://worker
 
-      - name: Scan result image with Sysdig CLI
+      - name: 🔍 Run Sysdig Scan (result)
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-            scan --apiurl "${SYSDIG_SECURE_URL}" docker://result
+              scan \
+              --apiurl $SYS_DIG_SECURE_URL \
+              --token $SECURE_API_TOKEN \
+              docker://result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,18 +1,14 @@
 name: Sysdig Image Scan
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   image-scan:
     runs-on: ubuntu-latest
-
-    env:
-      SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
-      SYS_DIG_SECURE_URL: https://app.au1.sysdig.com
 
     steps:
       - name: 🛎️ Checkout code
@@ -24,45 +20,48 @@ jobs:
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: 🔍 Scan voting-app with Sysdig
+      - name: 🛡️ Scan voting-app with Sysdig
+        env:
+          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
         run: |
           docker run --rm \
             --platform linux/amd64 \
             --user 0 \
-            -v "${{ github.workspace }}/scan-logs:/home/nonroot/scan-logs" \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
+            -e SECURE_API_TOKEN=$SECURE_API_TOKEN \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              --apiurl $SYS_DIG_SECURE_URL \
-              --loglevel debug \
+              --apiurl https://app.au1.sysdig.com \
+              --loglevel info \
               --skiptlsverify \
               docker://voting-app
 
-      - name: 🔍 Scan worker with Sysdig
+      - name: 🛡️ Scan worker with Sysdig
+        env:
+          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
         run: |
           docker run --rm \
             --platform linux/amd64 \
             --user 0 \
-            -v "${{ github.workspace }}/scan-logs:/home/nonroot/scan-logs" \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
+            -e SECURE_API_TOKEN=$SECURE_API_TOKEN \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              --apiurl $SYS_DIG_SECURE_URL \
-              --loglevel debug \
+              --apiurl https://app.au1.sysdig.com \
+              --loglevel info \
               --skiptlsverify \
               docker://worker
 
-      - name: 🔍 Scan result with Sysdig
+      - name: 🛡️ Scan result with Sysdig
+        env:
+          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
         run: |
           docker run --rm \
             --platform linux/amd64 \
             --user 0 \
-            -v "${{ github.workspace }}/scan-logs:/home/nonroot/scan-logs" \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
+            -e SECURE_API_TOKEN=$SECURE_API_TOKEN \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              --apiurl $SYS_DIG_SECURE_URL \
-              --loglevel debug \
+              --apiurl https://app.au1.sysdig.com \
+              --loglevel info \
               --skiptlsverify \
               docker://result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,42 +1,42 @@
-name: Sysdig Image Scan
+name: Voting App Build & Scan
 
 on:
   push:
     branches:
       - main
+  pull_request:
   workflow_dispatch:
 
 jobs:
-  image-scan:
+  build-and-scan:
     runs-on: ubuntu-latest
 
     env:
       SYS_DIG_SECURE_URL: https://app.au1.sysdig.com
 
     steps:
-      - name: Checkout code
+      - name: Checkout source
         uses: actions/checkout@v3
 
-      - name: Build Docker images
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to DockerHub (optional)
+        if: secrets.DOCKERHUB_USERNAME && secrets.DOCKERHUB_TOKEN
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build Voting App images
         run: |
           docker build -t voting-app ./vote
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: Debug
+      - name: Scan image with Sysdig CLI Scanner
         env:
           SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
-        run: |
-          echo "🔍 Token Length: ${#SECURE_API_TOKEN}"
-          echo "🔍 Token Head: ${SECURE_API_TOKEN:0:5}"
-          if [ -z "$SECURE_API_TOKEN" ]; then
-            echo "❌ SECURE_API_TOKEN is NOT set!"
-            exit 1
-          else
-            echo "✅ SECURE_API_TOKEN is available."
-          fi
-
-      - name: Run Sysdig Scan (voting-app)
         run: |
           docker run --rm \
             --platform linux/amd64 \
@@ -46,7 +46,7 @@ jobs:
             -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
               --apiurl "$SYS_DIG_SECURE_URL" \
-              --loglevel debug \
+              --loglevel info \
               --skiptlsverify \
               docker://voting-app
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -23,7 +23,7 @@ jobs:
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: Debug: Check if SECURE_API_TOKEN is available
+      - name: Debug
         env:
           SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
         run: |

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -23,18 +23,17 @@ jobs:
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: Debug: Check if SECURE_API_TOKEN is available
+      - name: Set SECURE_API_TOKEN env and debug
         run: |
-          echo "Token Length: ${#SECURE_API_TOKEN}"
-          echo "Token Head: ${SECURE_API_TOKEN:0:5}"
+          export SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}"
+          echo "🔍 Token Length: ${#SECURE_API_TOKEN}"
+          echo "🔍 Token Head: ${SECURE_API_TOKEN:0:5}"
           if [ -z "$SECURE_API_TOKEN" ]; then
-            echo "SECURE_API_TOKEN is NOT set!"
+            echo "❌ SECURE_API_TOKEN is NOT set!"
             exit 1
           else
-            echo "SECURE_API_TOKEN is available."
+            echo "✅ SECURE_API_TOKEN is available."
           fi
-        env:
-          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
 
       - name: Run Sysdig Scan (voting-app)
         run: |
@@ -43,9 +42,10 @@ jobs:
             --user 0 \
             -v "$(pwd)/scan-logs:/home/nonroot/scan-logs" \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
+            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              --apiurl $SYS_DIG_SECURE_URL \
+              --apiurl "$SYS_DIG_SECURE_URL" \
               --loglevel debug \
               --skiptlsverify \
               docker://voting-app
+

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,4 +1,4 @@
-name: Sysdig Image Scan
+name: Sysdig Container Scanner (Stable)
 
 on:
   push:
@@ -6,11 +6,11 @@ on:
   workflow_dispatch:
 
 jobs:
-  image-scan:
+  scan:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout source
+      - name: Checkout
         uses: actions/checkout@v3
 
       - name: Build Docker images
@@ -19,20 +19,28 @@ jobs:
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: Download Sysdig CLI Scanner
-        run: |
-          VERSION=$(curl -sSL https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt)
-          echo "Latest version: $VERSION"
-          curl -sSL "https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/${VERSION}/linux/amd64/sysdig-cli-scanner" -o sysdig-cli-scanner
-          chmod +x sysdig-cli-scanner
-          ./sysdig-cli-scanner --version
-
-      - name: Run Sysdig CLI Scanner
+      - name: Run Sysdig CLI Scanner (Dockerized)
         env:
           SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
-          SYS_DIG_SECURE_URL: https://app.au1.sysdig.com
         run: |
-          ./sysdig-cli-scanner --apiurl $SYS_DIG_SECURE_URL --token $SECURE_API_TOKEN docker://voting-app
-          ./sysdig-cli-scanner --apiurl $SYS_DIG_SECURE_URL --token $SECURE_API_TOKEN docker://worker
-          ./sysdig-cli-scanner --apiurl $SYS_DIG_SECURE_URL --token $SECURE_API_TOKEN docker://result
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            quay.io/sysdig/sysdig-cli-scanner:latest \
+              --apiurl https://app.au1.sysdig.com \
+              --token $SECURE_API_TOKEN \
+              docker://voting-app
+
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            quay.io/sysdig/sysdig-cli-scanner:latest \
+              --apiurl https://app.au1.sysdig.com \
+              --token $SECURE_API_TOKEN \
+              docker://worker
+
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            quay.io/sysdig/sysdig-cli-scanner:latest \
+              --apiurl https://app.au1.sysdig.com \
+              --token $SECURE_API_TOKEN \
+              docker://result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -49,4 +49,3 @@ jobs:
               --loglevel debug \
               --skiptlsverify \
               docker://voting-app
-

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -11,51 +11,57 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
+      - name: 🛎️ Checkout code
         uses: actions/checkout@v3
 
-      - name: Build Docker images
+      - name: 🏗️ Build Docker images
         run: |
           docker build -t voting-app ./vote
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: Run Sysdig Scan (voting-app)
+      - name: 🔍 Run Sysdig Scan (voting-app)
+        env:
+          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
         run: |
           docker run --rm \
             --platform linux/amd64 \
             --user 0 \
-            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
+            -e SECURE_API_TOKEN=$SECURE_API_TOKEN \
             -v /var/run/docker.sock:/var/run/docker.sock \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
+              scan \
               --apiurl https://app.au1.sysdig.com \
-              --loglevel info \
               --skiptlsverify \
               docker://voting-app
 
-      - name: Run Sysdig Scan (worker)
+      - name: 🔍 Run Sysdig Scan (worker)
+        env:
+          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
         run: |
           docker run --rm \
             --platform linux/amd64 \
             --user 0 \
-            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
+            -e SECURE_API_TOKEN=$SECURE_API_TOKEN \
             -v /var/run/docker.sock:/var/run/docker.sock \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
+              scan \
               --apiurl https://app.au1.sysdig.com \
-              --loglevel info \
               --skiptlsverify \
               docker://worker
 
-      - name: Run Sysdig Scan (result)
+      - name: 🔍 Run Sysdig Scan (result)
+        env:
+          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
         run: |
           docker run --rm \
             --platform linux/amd64 \
             --user 0 \
-            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
+            -e SECURE_API_TOKEN=$SECURE_API_TOKEN \
             -v /var/run/docker.sock:/var/run/docker.sock \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
+              scan \
               --apiurl https://app.au1.sysdig.com \
-              --loglevel info \
               --skiptlsverify \
               docker://result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,4 +1,4 @@
-name: Sysdig Container Scanner (Stable)
+name: Sysdig Image Scan
 
 on:
   push:
@@ -21,26 +21,27 @@ jobs:
 
       - name: Run Sysdig CLI Scanner (Dockerized)
         env:
-          SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
+          SYSDIG_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
+          SYSDIG_API_URL: https://app.au1.sysdig.com
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            quay.io/sysdig/sysdig-cli-scanner:latest \
-              --apiurl https://app.au1.sysdig.com \
-              --token $SECURE_API_TOKEN \
+            -e SYSDIG_API_TOKEN \
+            -e SYSDIG_API_URL \
+            quay.io/sysdig/sysdig-cli-scanner \
               docker://voting-app
 
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            quay.io/sysdig/sysdig-cli-scanner:latest \
-              --apiurl https://app.au1.sysdig.com \
-              --token $SECURE_API_TOKEN \
+            -e SYSDIG_API_TOKEN \
+            -e SYSDIG_API_URL \
+            quay.io/sysdig/sysdig-cli-scanner \
               docker://worker
 
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            quay.io/sysdig/sysdig-cli-scanner:latest \
-              --apiurl https://app.au1.sysdig.com \
-              --token $SECURE_API_TOKEN \
+            -e SYSDIG_API_TOKEN \
+            -e SYSDIG_API_URL \
+            quay.io/sysdig/sysdig-cli-scanner \
               docker://result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,1 +1,35 @@
-404: Not Found
+name: Sysdig Image Scan
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  image-scan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Build Docker images
+        run: |
+          docker build -t voting-app ./voting-app
+          docker build -t worker ./worker
+          docker build -t result ./result
+
+      - name: Download Sysdig CLI Scanner
+        run: |
+          curl -sL https://download.sysdig.com/scanning/sysdig-cli-scanner/latest/linux/sysdig-cli-scanner -o scanner
+          chmod +x scanner
+
+      - name: Run Sysdig Scan on voting-app
+        run: ./scanner --token ${{ secrets.SYSDIG_SECURE_TOKEN }} --image voting-app
+
+      - name: Run Sysdig Scan on worker
+        run: ./scanner --token ${{ secrets.SYSDIG_SECURE_TOKEN }} --image worker
+
+      - name: Run Sysdig Scan on result
+        run: ./scanner --token ${{ secrets.SYSDIG_SECURE_TOKEN }} --image result

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Download Sysdig CLI Scanner
         run: |
-          curl -sL https://download.sysdig.com/scanning/sysdig-cli-scanner/latest/linux/sysdig-cli-scanner -o scanner
+          curl -sLo scanner https://download.sysdig.com/scanning/sysdig-cli-scanner/latest/sysdig-cli-scanner-linux-amd64
           chmod +x scanner
 
       - name: Run Sysdig Scan on voting-app

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout source
+      - name: Checkout code
         uses: actions/checkout@v3
 
       - name: Build Docker images
@@ -20,18 +20,20 @@ jobs:
           docker build -t result ./result
 
       - name: Download Sysdig CLI Scanner
-        run: | 
-　　　　　version=$(curl -sSL https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt)
-    　　　echo "Latest version is $version"
-    　　　curl -sSL "https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/${version}/linux/amd64/sysdig-cli-scanner" -o sysdig-cli-scanner
-    　　　chmod +x sysdig-cli-scanner
-    　　　./sysdig-cli-scanner --version
-      - name: Run Sysdig Image Scan
+        run: |
+          echo "Fetching latest scanner version..."
+          VERSION=$(curl -sSL https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt)
+          echo "Latest version: $VERSION"
+          curl -sSL "https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/${VERSION}/linux/amd64/sysdig-cli-scanner" -o sysdig-cli-scanner
+          chmod +x sysdig-cli-scanner
+          ./sysdig-cli-scanner --version
+
+      - name: Run Sysdig Scan
         env:
           SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
           SYS_DIG_SECURE_URL: https://app.au1.sysdig.com
         run: |
-          ./scanner --apiurl $SYS_DIG_SECURE_URL --auth-token $SECURE_API_TOKEN docker://voting-app
-          ./scanner --apiurl $SYS_DIG_SECURE_URL --auth-token $SECURE_API_TOKEN docker://worker
-          ./scanner --apiurl $SYS_DIG_SECURE_URL --auth-token $SECURE_API_TOKEN docker://result
+          ./sysdig-cli-scanner --apiurl $SYS_DIG_SECURE_URL --auth-token $SECURE_API_TOKEN docker://voting-app
+          ./sysdig-cli-scanner --apiurl $SYS_DIG_SECURE_URL --auth-token $SECURE_API_TOKEN docker://worker
+          ./sysdig-cli-scanner --apiurl $SYS_DIG_SECURE_URL --auth-token $SECURE_API_TOKEN docker://result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -17,7 +17,7 @@ jobs:
       - name: 🛎️ Checkout code
         uses: actions/checkout@v3
 
-      - name: 🐳 Build Docker images
+      - name: 🏗️ Build Docker images
         run: |
           docker build -t voting-app ./vote
           docker build -t worker ./worker
@@ -41,37 +41,12 @@ jobs:
           docker run --rm \
             --platform linux/amd64 \
             --user 0 \
+            -v "$(pwd)/scan-logs:/home/nonroot/scan-logs" \
             -v /var/run/docker.sock:/var/run/docker.sock \
             -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
               --apiurl $SYS_DIG_SECURE_URL \
-              --skiptlsverify \
               --loglevel debug \
+              --skiptlsverify \
               docker://voting-app
-
-      - name: 🔍 Run Sysdig Scan (worker)
-        run: |
-          docker run --rm \
-            --platform linux/amd64 \
-            --user 0 \
-            -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
-            quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              --apiurl $SYS_DIG_SECURE_URL \
-              --skiptlsverify \
-              --loglevel debug \
-              docker://worker
-
-      - name: 🔍 Run Sysdig Scan (result)
-        run: |
-          docker run --rm \
-            --platform linux/amd64 \
-            --user 0 \
-            -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
-            quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              --apiurl $SYS_DIG_SECURE_URL \
-              --skiptlsverify \
-              --loglevel debug \
-              docker://result
 

--- a/k8s-specifications/db-deployment.yaml
+++ b/k8s-specifications/db-deployment.yaml
@@ -1,8 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  labels:
-    app: db
   name: db
 spec:
   replicas: 1
@@ -14,20 +12,33 @@ spec:
       labels:
         app: db
     spec:
+      serviceAccountName: default
       containers:
-      - image: postgres:15-alpine
-        name: postgres
-        env:
-        - name: POSTGRES_USER
-          value: postgres
-        - name: POSTGRES_PASSWORD
-          value: postgres
-        ports:
-        - containerPort: 5432
-          name: postgres
-        volumeMounts:
-        - mountPath: /var/lib/postgresql/data
-          name: db-data
-      volumes:
-      - name: db-data
-        emptyDir: {} 
+      - name: postgres
+        image: postgres:15
+        securityContext:
+          runAsUser: 1000
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "500m"
+            memory: "256Mi"
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 5

--- a/k8s-specifications/redis-deployment.yaml
+++ b/k8s-specifications/redis-deployment.yaml
@@ -1,8 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  labels:
-    app: redis
   name: redis
 spec:
   replicas: 1
@@ -14,15 +12,33 @@ spec:
       labels:
         app: redis
     spec:
+      serviceAccountName: default
       containers:
-      - image: redis:alpine
-        name: redis
-        ports:
-        - containerPort: 6379
-          name: redis
-        volumeMounts:
-        - mountPath: /data
-          name: redis-data
-      volumes:
-      - name: redis-data
-        emptyDir: {} 
+      - name: redis
+        image: redis:7
+        securityContext:
+          runAsUser: 1000
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "500m"
+            memory: "256Mi"
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 5

--- a/k8s-specifications/result-deployment.yaml
+++ b/k8s-specifications/result-deployment.yaml
@@ -1,8 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  labels:
-    app: result
   name: result
 spec:
   replicas: 1
@@ -14,9 +12,33 @@ spec:
       labels:
         app: result
     spec:
+      serviceAccountName: default
       containers:
-      - image: dockersamples/examplevotingapp_result
-        name: result
-        ports:
-        - containerPort: 80
-          name: result
+      - name: result
+        image: dockersamples/examplevotingapp_result
+        securityContext:
+          runAsUser: 1000
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "500m"
+            memory: "256Mi"
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 5

--- a/k8s-specifications/vote-deployment.yaml
+++ b/k8s-specifications/vote-deployment.yaml
@@ -1,8 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  labels:
-    app: vote
   name: vote
 spec:
   replicas: 1
@@ -14,9 +12,33 @@ spec:
       labels:
         app: vote
     spec:
+      serviceAccountName: default
       containers:
-      - image: dockersamples/examplevotingapp_vote
-        name: vote
-        ports:
-        - containerPort: 80
-          name: vote
+      - name: vote
+        image: dockersamples/examplevotingapp_vote
+        securityContext:
+          runAsUser: 1000
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "500m"
+            memory: "256Mi"
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 5

--- a/k8s-specifications/worker-deployment.yaml
+++ b/k8s-specifications/worker-deployment.yaml
@@ -1,8 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  labels:
-    app: worker
   name: worker
 spec:
   replicas: 1
@@ -14,6 +12,33 @@ spec:
       labels:
         app: worker
     spec:
+      serviceAccountName: default
       containers:
-      - image: dockersamples/examplevotingapp_worker
-        name: worker
+      - name: worker
+        image: worker
+        securityContext:
+          runAsUser: 1000
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "500m"
+            memory: "256Mi"
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 5


### PR DESCRIPTION
This PR applies security best practices to Kubernetes manifests based on IaC scan results using Sysdig CLI Scanner.

✅ Improvements:
- Set `serviceAccountName` on all workloads
- Dropped all Linux capabilities
- Enabled `readOnlyRootFilesystem`
- Added `runAsUser: 1000` and `runAsNonRoot: true`
- Defined CPU and memory `requests` and `limits`
- Added basic `livenessProbe` and `readinessProbe`

Scan date: 2025-07-16
Tool: Sysdig CLI Scanner 1.22.4
[sysdig-iac-fix-report.md](https://github.com/user-attachments/files/21258165/sysdig-iac-fix-report.md)
# Sysdig IaC Scan 修正提案レポート

- **対象リポジトリ**: [example-voting-app](https://github.com/dockersamples/example-voting-app)
- **スキャン実行日**: 2025年07月16日
- **使用ツール**: Sysdig CLI Scanner v1.22.4

---

## 🔴 High Severity Issues & 修正案

### 1. `serviceAccountName` が未設定
**対象**: db, redis, vote, result, worker

```yaml
spec:
  serviceAccountName: default
```

---

### 2. rootユーザーでの実行 (`runAsUser` 未定義)
```yaml
securityContext:
  runAsUser: 1000
  runAsNonRoot: true
```

---

### 3. ルートファイルシステムが書き込み可能
```yaml
securityContext:
  readOnlyRootFilesystem: true
```

---

### 4. `capabilities` に `NET_RAW` などが含まれている
```yaml
securityContext:
  capabilities:
    drop:
      - ALL
```

---

## 🟠 Medium Severity Issues & 修正案

### 5. リソース制限とリクエストが未設定

```yaml
resources:
  requests:
    cpu: "100m"
    memory: "128Mi"
  limits:
    cpu: "500m"
    memory: "256Mi"
```

---

### 6. `livenessProbe` / `readinessProbe` が未設定

```yaml
livenessProbe:
  httpGet:
    path: /
    port: 80
  initialDelaySeconds: 5
  periodSeconds: 10

readinessProbe:
  httpGet:
    path: /
    port: 80
  initialDelaySeconds: 5
  periodSeconds: 5
```

---



