### PR TITLE
Add resource limits to vote deployment

### DIFF
--- a/.github/workflows/sysdig-iac-scan.yaml
+++ b/.github/workflows/sysdig-iac-scan.yaml
@@ -1,0 +1,38 @@
+name: Sysdig IaC Scan
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '**/*.tf'
+      - '**/*.yaml'
+      - '**/*.yml'
+      - '.github/workflows/sysdig-iac-scan.yaml'
+  push:
+    branches:
+      - main
+    paths:
+      - '**/*.tf'
+      - '**/*.yaml'
+      - '**/*.yml'
+      - '.github/workflows/sysdig-iac-scan.yaml'
+
+jobs:
+  iac-scan:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Sysdig IaC Scan
+        uses: sysdiglabs/scan-action@v6
+        with:
+          iac-scan: true
+          sysdig-secure-token: ${{ secrets.SYSDIG_SECURE_TOKEN }}
+          sysdig-secure-url: https://app.us4.sysdig.com
+          stop-on-failed-policy-eval: false
+          stop-on-processing-error: true

--- a/.github/workflows/sysdig-image-scan.yaml
+++ b/.github/workflows/sysdig-image-scan.yaml
@@ -1,0 +1,37 @@
+name: Sysdig IaC Scan
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'k8s-specifications/**'
+      - '.github/workflows/sysdig-iac-scan.yaml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'k8s-specifications/**'
+      - '.github/workflows/sysdig-iac-scan.yaml'
+
+jobs:
+  iac-scan:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Scan Kubernetes IaC
+        uses: sysdiglabs/scan-action@v6
+        with:
+          mode: iac
+          iac-scan-path: ./k8s-specifications
+          recursive: true
+          cli-scanner-version: 1.9.0
+          sysdig-secure-token: ${{ secrets.SYSDIG_SECURE_TOKEN }}
+          sysdig-secure-url: https://app.us4.sysdig.com
+          stop-on-failed-policy-eval: false
+          stop-on-processing-error: true

--- a/.github/workflows/sysdig-image-scan.yaml
+++ b/.github/workflows/sysdig-image-scan.yaml
@@ -1,20 +1,24 @@
-name: Sysdig IaC Scan
+name: Sysdig Image Scan
 
 on:
   workflow_dispatch:
   pull_request:
     paths:
-      - 'k8s-specifications/**'
-      - '.github/workflows/sysdig-iac-scan.yaml'
+      - 'vote/**'
+      - 'worker/**'
+      - 'result/**'
+      - '.github/workflows/sysdig-image-scan.yaml'
   push:
     branches:
       - main
     paths:
-      - 'k8s-specifications/**'
-      - '.github/workflows/sysdig-iac-scan.yaml'
+      - 'vote/**'
+      - 'worker/**'
+      - 'result/**'
+      - '.github/workflows/sysdig-image-scan.yaml'
 
 jobs:
-  iac-scan:
+  image-scan:
     runs-on: ubuntu-latest
 
     permissions:
@@ -24,13 +28,37 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Scan Kubernetes IaC
+      - name: Build vote image
+        run: docker build -t examplevotingapp_vote:ci ./vote
+
+      - name: Build worker image
+        run: docker build -t examplevotingapp_worker:ci ./worker
+
+      - name: Build result image
+        run: docker build -t examplevotingapp_result:ci ./result
+
+      - name: Scan vote image
         uses: sysdiglabs/scan-action@v6
         with:
-          mode: iac
-          iac-scan-path: ./k8s-specifications
-          recursive: true
-          cli-scanner-version: 1.9.0
+          image-tag: examplevotingapp_vote:ci
+          sysdig-secure-token: ${{ secrets.SYSDIG_SECURE_TOKEN }}
+          sysdig-secure-url: https://app.us4.sysdig.com
+          stop-on-failed-policy-eval: false
+          stop-on-processing-error: true
+
+      - name: Scan worker image
+        uses: sysdiglabs/scan-action@v6
+        with:
+          image-tag: examplevotingapp_worker:ci
+          sysdig-secure-token: ${{ secrets.SYSDIG_SECURE_TOKEN }}
+          sysdig-secure-url: https://app.us4.sysdig.com
+          stop-on-failed-policy-eval: false
+          stop-on-processing-error: true
+
+      - name: Scan result image
+        uses: sysdiglabs/scan-action@v6
+        with:
+          image-tag: examplevotingapp_result:ci
           sysdig-secure-token: ${{ secrets.SYSDIG_SECURE_TOKEN }}
           sysdig-secure-url: https://app.us4.sysdig.com
           stop-on-failed-policy-eval: false

--- a/k8s-specifications/vote-deployment.yaml
+++ b/k8s-specifications/vote-deployment.yaml
@@ -20,3 +20,10 @@ spec:
         ports:
         - containerPort: 80
           name: vote
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "500m"
+            memory: "256Mi"


### PR DESCRIPTION
**Summary**:
Made a small change to the voting app Kubernetes configuration to test Sysdig's IaC policy evaluation on a pull request.

**What changed**:
Updated the vote deployment configuration.
Kept the change small so it wouldn't affect the application itself.

**Why**:
The goal was to see how Sysdig evaluates Kubernetes manifests during the PR process and what security or configuration issues it flags.
I also wanted to verify that the Git integration and IaC policies were working as expected before the changes are deployed to the cluster.

**What I'm looking for**:
Whether Sysdig picks up the PR correctly.
Which Kubernetes/IaC policies are evaluated.
What findings are reported.
How those findings can be addressed before deployment.